### PR TITLE
Update FAQ content and remove obsolete entries

### DIFF
--- a/docs/faq_data_en.json
+++ b/docs/faq_data_en.json
@@ -1,13 +1,9 @@
 {
-  "version": 4,
+  "version": 5,
   "categories": [
     {
       "title": "Welcome to Sagas",
       "items": [
-        {
-          "question": "Wait, I thought this was 'SagAI'?",
-          "answer": "Good eye! We've evolved. 'Sagas' is the final, epic name for our platform. It's the same AI-powered storytelling you love, just with a name that better fits the legendary tales you're creating."
-        },
         {
           "question": "What exactly is Sagas?",
           "answer": "Sagas is your personal AI co-author and Art Director. You don't just 'play' a game; you live an evolving story across different genres, where your choices literally shape the world, characters, and even the art you see."
@@ -26,12 +22,24 @@
           "answer": "Stories are divided into Acts and Chapters. As you interact, the AI recaps previous events into a 'Saga Resume' and generates new introductions to keep the narrative tight. You can also manually start a 'New Chapter' to summarize current events and move to the next phase of your journey."
         },
         {
-          "question": "What's the difference between 'Talk', 'Think', and 'Action'?",
-          "answer": "'Talk' is what your character says aloud to NPCs. 'Think' is internal—only you (and the narrator) know these secrets. 'Action' describes physical movements that change the scene. NPCs react differently based on which one you choose!"
+          "question": "How do I express actions or thoughts?",
+          "answer": "You can use tags! Type <action>jumps</action> for physical moves, <think>secrets</think> for internal monologue, or <narrator>meanwhile</narrator> for world details. Or just use the buttons above your keyboard!"
+        },
+        {
+          "question": "Can I edit my messages?",
+          "answer": "Yes, but only the most recent one. This keeps the timeline intact and prevents 'time travel' paradoxes where changing the past would confuse the AI's current response."
+        },
+        {
+          "question": "Can I delete messages?",
+          "answer": "Absolutely. You can delete any message to clean up your story. Just tap on the message options. If you delete the last message, you can try again!"
         },
         {
           "question": "Can I add more characters?",
           "answer": "Yes! Use the 'New Character' action to introduce allies, rivals, or mysterious strangers. You can even describe their appearance and backstory, and the AI will remember them throughout the saga."
+        },
+        {
+          "question": "What is Saga Wrapped?",
+          "answer": "When your story reaches a conclusion, we generate a special 'Saga Wrapped' — a stylish, shareable retrospective of your journey, your character's stats, and your best moments."
         }
       ]
     },

--- a/docs/faq_data_pt.json
+++ b/docs/faq_data_pt.json
@@ -1,13 +1,9 @@
 {
-  "version": 4,
+  "version": 5,
   "categories": [
     {
       "title": "Boas-vindas ao Sagas",
       "items": [
-        {
-          "question": "Ué, o nome não era 'SagAI'?",
-          "answer": "Bem observado! Nós evoluímos. 'Sagas' é o nome final e épico da nossa plataforma. É a mesma narrativa por IA que você adora, mas com um nome que combina muito mais com os contos lendários que você está criando."
-        },
         {
           "question": "O que exatamente é o Sagas?",
           "answer": "O Sagas é seu coautor e Diretor de Arte pessoal. Você não apenas 'joga'; você vive uma história em evolução em diferentes gêneros, onde suas escolhas moldam literalmente o mundo, os personagens e até a arte que você vê."
@@ -26,12 +22,24 @@
           "answer": "As histórias são divididas em Atos e Capítulos. Conforme você interage, a IA resume os eventos anteriores em um 'Resumo da Saga' e gera novas introduções. Você também pode iniciar um 'Novo Capítulo' manualmente para consolidar os eventos atuais e avançar."
         },
         {
-          "question": "Qual a diferença entre 'Falar', 'Pensar' e 'Ação'?",
-          "answer": "'Falar' é o que seu personagem diz em voz alta. 'Pensar' é interno — apenas você (e o narrador) sabem desses segredos. 'Ação' descreve movimentos físicos. Os NPCs reagem de forma diferente dependendo do que você escolhe!"
+          "question": "Como expresso ações ou pensamentos?",
+          "answer": "Use as tags! Digite <action>pula</action> para ações, <think>segredos</think> para pensamentos, ou <narrator>enquanto isso</narrator> para detalhes do narrador. Ou use os botões acima do teclado!"
+        },
+        {
+          "question": "Posso editar minhas mensagens?",
+          "answer": "Sim, mas apenas a mais recente. Isso mantém a linha do tempo intacta e evita paradoxos de 'viagem no tempo' que confundiriam a resposta atual da IA."
+        },
+        {
+          "question": "Como apago uma mensagem?",
+          "answer": "Você pode apagar qualquer mensagem para limpar sua história. Basta tocar nas opções da mensagem. Se apagar a última, pode tentar de novo!"
         },
         {
           "question": "Posso adicionar mais personagens?",
           "answer": "Sim! Use a ação 'Novo Personagem' para introduzir aliados, rivais ou estranhos misteriosos. Você pode descrever a aparência e o passado deles, e a IA se lembrará de tudo durante a saga."
+        },
+        {
+          "question": "O que é o Saga Wrapped?",
+          "answer": "Quando sua história chega ao fim, geramos um 'Saga Wrapped' especial — uma retrospectiva estilosa e compartilhável da sua jornada, estatísticas do personagem e melhores momentos."
         }
       ]
     },


### PR DESCRIPTION
This PR updates the FAQ content in `docs/faq_data_en.json` and `docs/faq_data_pt.json`.

Changes include:
1.  **Removal**: Removed the section explaining the name change from "SagAI" to "Sagas", as it is no longer relevant.
2.  **Enhancement**:
    *   Updated the question about "Talk, Think, and Action" to explicitly explain the new Expressive Message tags (`<action>`, `<think>`, `<narrator>`).
    *   Added a question explaining that only the last message can be edited to preserve narrative flow.
    *   Added a question explaining that any message can be deleted.
    *   Added a question explaining the "Saga Wrapped" feature.
3.  **Version**: Incremented the FAQ version to 5.

---
*PR created automatically by Jules for task [8866298841026397512](https://jules.google.com/task/8866298841026397512) started by @CaioProgramming*