### PR TITLE
Refactor Android logging to use Timber

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
@@ -2,7 +2,6 @@ package com.ilustris.sagai.core.ai
 
 import android.graphics.Bitmap
 import android.util.Base64
-import android.util.Log
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.JsonSyntaxException
@@ -315,7 +314,7 @@ class GemmaClient
                                 Timber.i("Generation Bench: $model took ${duration}ms (Prompt: $promptLength chars)")
                             }
                             val data = aiGeneration.data
-                            if (logEnabled) Log.d(javaClass.simpleName, "AI data ->\n$data\n")
+                            if (logEnabled) Timber.d("AI data ->\n$data\n")
                             data
                         }
                     } catch (e: Exception) {
@@ -333,17 +332,11 @@ class GemmaClient
                                     ),
                                 )
                             } catch (logEx: Exception) {
-                                Log.e(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "Error saving log: ${logEx.message}",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).e("Error saving log: ${logEx.message}")
                             }
                         }
                         if (logEnabled) {
-                            Log.e(
-                                this@GemmaClient::class.java.simpleName,
-                                "Error in Generation($model) Attempt $currentAttempt/$maxAttempts: ${e.javaClass.simpleName} - ${e.message}",
-                            )
+                            Timber.tag(this@GemmaClient::class.java.simpleName).e("Error in Generation($model) Attempt $currentAttempt/$maxAttempts: ${e.javaClass.simpleName} - ${e.message}")
                         }
 
                         // Check if it's a parsing error (no delay needed) or network error (delay recommended)
@@ -354,10 +347,7 @@ class GemmaClient
                         if (e is HttpException) {
                             val errorBody = e.response()?.errorBody()?.string()
                             if (logEnabled) {
-                                Log.e(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "HTTP Error ($model): $errorBody",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).e("HTTP Error ($model): $errorBody")
                             }
 
                             try {
@@ -376,24 +366,15 @@ class GemmaClient
 
                                 errorResponse.error?.details?.forEach { detail ->
                                     detail.violations?.forEach { violation ->
-                                        Log.w(
-                                            this@GemmaClient::class.java.simpleName,
-                                            "Quota Violation: ${violation.quotaId} - ${violation.quotaMetric} (Value: ${violation.quotaValue})",
-                                        )
+                                        Timber.tag(this@GemmaClient::class.java.simpleName).w("Quota Violation: ${violation.quotaId} - ${violation.quotaMetric} (Value: ${violation.quotaValue})")
                                     }
                                 }
 
                                 if (extractedDelay != null) {
-                                    Log.i(
-                                        this@GemmaClient::class.java.simpleName,
-                                        "Extracted precise delay from error: $extractedDelay seconds",
-                                    )
+                                    Timber.tag(this@GemmaClient::class.java.simpleName).i("Extracted precise delay from error: $extractedDelay seconds")
                                 }
                             } catch (parseEx: Exception) {
-                                Log.e(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "Failed to parse error body: ${parseEx.message}",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).e("Failed to parse error body: ${parseEx.message}")
                             }
                         }
 
@@ -402,16 +383,10 @@ class GemmaClient
                                 if (isParsingError) 0L else (extractedDelay ?: RETRY_DELAY.toLong())
 
                             if (delayToApply > 0) {
-                                Log.w(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "Retrying HIGH priority request in $delayToApply seconds due to ${e.javaClass.simpleName}...",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).w("Retrying HIGH priority request in $delayToApply seconds due to ${e.javaClass.simpleName}...")
                                 delay(delayToApply.seconds)
                             } else {
-                                Log.w(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "Retrying immediately due to parsing error (${e.javaClass.simpleName})...",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).w("Retrying immediately due to parsing error (${e.javaClass.simpleName})...")
                             }
                         } else {
                             // Final failure
@@ -421,12 +396,9 @@ class GemmaClient
                                         if (it > 30) it / 2 else it + it
                                     } ?: 2
                             }
-                            Log.e(
-                                javaClass.simpleName,
-                                "Final failure after $maxAttempts attempts.",
-                            )
-                            Log.e(javaClass.simpleName, "generate: Failed prompt")
-                            Log.w(javaClass.simpleName, prompt)
+                            Timber.e("Final failure after $maxAttempts attempts.")
+                            Timber.e("generate: Failed prompt")
+                            Timber.w(prompt)
                             return@withContext null
                         }
                     }
@@ -613,10 +585,7 @@ class GemmaClient
 
                                     try {
                                         if (logEnabled) {
-                                            Log.i(
-                                                javaClass.simpleName,
-                                                "generateStreaming: Trying to parse $jsonStr",
-                                            )
+                                            Timber.i("generateStreaming: Trying to parse $jsonStr")
                                         }
                                         val partialResponse =
                                             Gson().fromJson(
@@ -666,19 +635,13 @@ class GemmaClient
                                 Timber.i("Generation Streaming Bench: $model took ${duration}ms")
                             }
 
-                            Log.d(
-                                javaClass.simpleName,
-                                "generateStreaming: final state on streaming:\n${aiGeneration.toJsonFormat()}",
-                            )
+                            Timber.d("generateStreaming: final state on streaming:\n${aiGeneration.toJsonFormat()}")
                             emit(StreamingState.Success(aiGeneration.data))
                             retryDelay = null
                             return@flow
                         } catch (e: Exception) {
                             if (logEnabled) {
-                                Log.e(
-                                    this@GemmaClient::class.java.simpleName,
-                                    "Error in Stream Generation($model) Attempt $currentAttempt/$maxAttempts: ${e.javaClass.simpleName} - ${e.message}",
-                                )
+                                Timber.tag(this@GemmaClient::class.java.simpleName).e("Error in Stream Generation($model) Attempt $currentAttempt/$maxAttempts: ${e.javaClass.simpleName} - ${e.message}")
                             }
 
                             val isParsingError =

--- a/app/src/main/java/com/ilustris/sagai/core/ai/services/GenreVisualConfigService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/services/GenreVisualConfigService.kt
@@ -1,9 +1,9 @@
 package com.ilustris.sagai.core.ai.services
 
-import android.util.Log
 import com.ilustris.sagai.core.ai.model.GenreVisualConfig
 import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.features.newsaga.data.model.Genre
+import timber.log.Timber
 
 /**
  * Fetches and caches [GenreVisualConfig] from Firebase Remote Config.
@@ -20,28 +20,25 @@ class GenreVisualConfigService(
     private val cache = mutableMapOf<Genre, GenreVisualConfig?>()
 
     suspend fun getVisualConfig(genre: Genre): GenreVisualConfig? {
-        Log.d("GenreVisualConfigService", "Requesting config for $genre")
+        Timber.tag("GenreVisualConfigService").d("Requesting config for $genre")
         if (cache.containsKey(genre) && cache[genre] != null) {
-            Log.d("GenreVisualConfigService", "Returning cached config for $genre")
+            Timber.tag("GenreVisualConfigService").d("Returning cached config for $genre")
             return cache[genre]
         }
 
         val key = "${genre.name.lowercase()}_visual_config"
-        Log.d("GenreVisualConfigService", "Fetching from remote config with key: $key")
+        Timber.tag("GenreVisualConfigService").d("Fetching from remote config with key: $key")
         val config =
             try {
                 remoteConfigService.getJson<GenreVisualConfig>(key)
             } catch (e: Exception) {
-                Log.e(
-                    "GenreVisualConfigService",
-                    "Failed to fetch visual config for $genre: ${e.message}",
-                )
+                Timber.tag("GenreVisualConfigService").e("Failed to fetch visual config for $genre: ${e.message}")
                 null
             }
         if (config != null) {
             cache[genre] = config
         } else {
-            Log.w("GenreVisualConfigService", "Config for $genre is null/empty in Remote Config")
+            Timber.tag("GenreVisualConfigService").w("Config for $genre is null/empty in Remote Config")
         }
         return config
     }

--- a/app/src/main/java/com/ilustris/sagai/core/ai/services/PromptService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/services/PromptService.kt
@@ -1,11 +1,11 @@
 package com.ilustris.sagai.core.ai.services
 
-import android.util.Log
 import com.ilustris.sagai.core.ai.model.PromptBlueprint
 import com.ilustris.sagai.core.ai.prompts.PromptDirectives
 import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.core.utils.toPromptVariables
 import javax.inject.Inject
+import timber.log.Timber
 
 interface PromptService {
     /**
@@ -66,7 +66,7 @@ class PromptServiceImpl
             logEnabled: Boolean,
         ): String {
             if (logEnabled) {
-                Log.i("PromptService", "buildPrompt: Received vars ->\n$variables")
+                Timber.tag("PromptService").i("buildPrompt: Received vars ->\n$variables")
             }
 
             val placeholders =
@@ -74,10 +74,7 @@ class PromptServiceImpl
             val uniquePlaceholders = placeholders.distinct()
 
             if (logEnabled) {
-                Log.i(
-                    "PromptService",
-                    "buildPrompt: Found ${placeholders.size} placeholders (${uniquePlaceholders.size} unique) in template: $uniquePlaceholders",
-                )
+                Timber.tag("PromptService").i("buildPrompt: Found ${placeholders.size} placeholders (${uniquePlaceholders.size} unique) in template: $uniquePlaceholders")
             }
 
             var result = template
@@ -87,18 +84,15 @@ class PromptServiceImpl
                 if (value != null) {
                     result = result.replace("{$key}", value)
                     if (logEnabled) {
-                        Log.d("PromptService", "buildPrompt: Replaced {$key}")
+                        Timber.tag("PromptService").d("buildPrompt: Replaced {$key}")
                     }
                 } else {
-                    Log.e(
-                        "PromptService",
-                        "buildPrompt: CRITICAL - Variable '{$key}' not found in provided args!",
-                    )
+                    Timber.tag("PromptService").e("buildPrompt: CRITICAL - Variable '{$key}' not found in provided args!")
                 }
             }
 
             if (logEnabled) {
-                Log.d("PromptService", "buildPrompt: Final Prompt Construction Complete.")
+                Timber.tag("PromptService").d("buildPrompt: Final Prompt Construction Complete.")
             }
             return result
         }
@@ -109,10 +103,7 @@ class PromptServiceImpl
             logEnabled: Boolean,
         ): String {
             val stringMap = variablesDataClass.toPromptVariables()
-            Log.d(
-                "PromptService",
-                "buildPrompt: Converted ${variablesDataClass::class.java.simpleName} to Map with ${stringMap.size} keys",
-            )
+            Timber.tag("PromptService").d("buildPrompt: Converted ${variablesDataClass::class.java.simpleName} to Map with ${stringMap.size} keys")
             return buildPrompt(template, stringMap, logEnabled)
         }
 
@@ -125,7 +116,7 @@ class PromptServiceImpl
                 remoteConfigService.getJson<PromptBlueprint>(remoteConfigKey, logEnabled)!!
 
             if (logEnabled) {
-                Log.d("PromptService", "buildRemotePrompt: Found Blueprint for '$remoteConfigKey'")
+                Timber.tag("PromptService").d("buildRemotePrompt: Found Blueprint for '$remoteConfigKey'")
             }
             if (blueprint.template.isBlank()) {
                 throw IllegalStateException(

--- a/app/src/main/java/com/ilustris/sagai/core/media/MediaPlayerManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/media/MediaPlayerManagerImpl.kt
@@ -2,7 +2,6 @@ package com.ilustris.sagai.core.media
 
 import android.content.Context
 import android.media.MediaPlayer
-import android.util.Log
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -56,9 +55,9 @@ class MediaPlayerManagerImpl
                 }
 
                 mediaPlayer?.apply {
-                    Log.d(javaClass.simpleName, "Resetting MediaPlayer.")
+                    Timber.d("Resetting MediaPlayer.")
                     reset()
-                    Log.d(javaClass.simpleName, "Setting data source: ${file.absolutePath}")
+                    Timber.d("Setting data source: ${file.absolutePath}")
                     setDataSource(file.absolutePath)
                     isLooping = looping
                     setOnPreparedListener {
@@ -84,7 +83,7 @@ class MediaPlayerManagerImpl
                         release()
                         mediaPlayer = null
                     }
-                    Log.d(javaClass.simpleName, "Calling prepareAsync.")
+                    Timber.d("Calling prepareAsync.")
                     prepareAsync()
                 }
             } catch (e: Exception) {

--- a/app/src/main/java/com/ilustris/sagai/core/media/SagaPlaybackService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/media/SagaPlaybackService.kt
@@ -8,7 +8,6 @@ import android.content.IntentFilter
 import android.media.AudioManager
 import android.os.Binder
 import android.os.IBinder
-import android.util.Log
 import com.ilustris.sagai.features.settings.domain.SettingsUseCase
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
@@ -17,6 +16,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 @AndroidEntryPoint
 class SagaPlaybackService : Service() {
@@ -42,7 +42,7 @@ class SagaPlaybackService : Service() {
                 intent: Intent?,
             ) {
                 if (intent?.action == AudioManager.RINGER_MODE_CHANGED_ACTION) {
-                    Log.d(TAG, "Ringer mode changed, updating playback")
+                    Timber.d("Ringer mode changed, updating playback")
                     updatePlayback()
                 }
             }
@@ -56,7 +56,7 @@ class SagaPlaybackService : Service() {
 
     override fun onCreate() {
         super.onCreate()
-        Log.i(TAG, "SagaPlaybackService created")
+        Timber.i("SagaPlaybackService created")
         registerReceiver(ringerModeReceiver, IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION))
         observeMusicSettings()
     }
@@ -66,7 +66,7 @@ class SagaPlaybackService : Service() {
         musicObserverJob =
             serviceScope.launch {
                 settingsUseCase.getMusicEnabled().collectLatest { enabled ->
-                    Log.d(TAG, "Music setting changed: enabled=$enabled")
+                    Timber.d("Music setting changed: enabled=$enabled")
                     musicEnabledBySettings = enabled
                     updatePlayback()
                 }
@@ -78,14 +78,11 @@ class SagaPlaybackService : Service() {
         val isSilent = isSilentMode()
         val shouldPlay = musicEnabledBySettings && !isSilent
 
-        Log.d(
-            TAG,
-            "updatePlayback: shouldPlay=$shouldPlay (settings=$musicEnabledBySettings, silent=$isSilent)",
-        )
+        Timber.d("updatePlayback: shouldPlay=$shouldPlay (settings=$musicEnabledBySettings, silent=$isSilent)")
 
         if (shouldPlay) {
             if (!mediaPlayerManager.isPlaying.value) {
-                Log.i(TAG, "Starting/Resuming music: $path")
+                Timber.i("Starting/Resuming music: $path")
                 mediaPlayerManager.prepareDataSource(
                     path,
                     looping = true,
@@ -96,7 +93,7 @@ class SagaPlaybackService : Service() {
             }
         } else {
             if (mediaPlayerManager.isPlaying.value) {
-                Log.i(TAG, "Stopping music due to silence/settings")
+                Timber.i("Stopping music due to silence/settings")
                 mediaPlayerManager.stop()
             }
         }
@@ -109,18 +106,18 @@ class SagaPlaybackService : Service() {
     }
 
     fun stopMusic() {
-        Log.i(TAG, "Stopping music playback")
+        Timber.i("Stopping music playback")
         mediaPlayerManager.stop()
         currentMusicPath = null
     }
 
     fun pauseMusic() {
-        Log.i(TAG, "Pausing music playback")
+        Timber.i("Pausing music playback")
         mediaPlayerManager.pause()
     }
 
     fun resumeMusic() {
-        Log.i(TAG, "Resume requested")
+        Timber.i("Resume requested")
         updatePlayback()
     }
 
@@ -130,10 +127,7 @@ class SagaPlaybackService : Service() {
         val notificationVolume = audioManager.getStreamVolume(AudioManager.STREAM_NOTIFICATION)
 
         val isMuted = ringerMode != AudioManager.RINGER_MODE_NORMAL || notificationVolume == 0
-        Log.d(
-            TAG,
-            "isSilentMode: ringerMode=$ringerMode, notificationVolume=$notificationVolume -> $isMuted",
-        )
+        Timber.d("isSilentMode: ringerMode=$ringerMode, notificationVolume=$notificationVolume -> $isMuted")
         return isMuted
     }
 
@@ -145,7 +139,7 @@ class SagaPlaybackService : Service() {
         val action = intent?.action
         val path = intent?.getStringExtra(EXTRA_MUSIC_PATH)
 
-        Log.d(TAG, "onStartCommand: action=$action")
+        Timber.d("onStartCommand: action=$action")
 
         when (action) {
             ACTION_START -> path?.let { startMusic(it) }
@@ -162,7 +156,7 @@ class SagaPlaybackService : Service() {
         unregisterReceiver(ringerModeReceiver)
         stopMusic()
         serviceJob.cancel()
-        Log.i(TAG, "SagaPlaybackService destroyed")
+        Timber.i("SagaPlaybackService destroyed")
     }
 
     companion object {

--- a/app/src/main/java/com/ilustris/sagai/core/notifications/NotificationGenerationWorker.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/notifications/NotificationGenerationWorker.kt
@@ -4,7 +4,6 @@ import android.app.AlarmManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
@@ -29,6 +28,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeout
 import kotlin.time.Duration.Companion.seconds
+import timber.log.Timber
 
 @HiltWorker
 class NotificationGenerationWorker
@@ -46,10 +46,10 @@ class NotificationGenerationWorker
         override suspend fun doWork(): Result {
             return try {
                 withTimeout(60.seconds) {
-                    Log.d(javaClass.simpleName, "Generating notification...")
+                    Timber.d("Generating notification...")
                     val sagaId = inputData.getInt(KEY_SAGA_ID, -1)
                     if (sagaId == -1) {
-                        Log.e(TAG, "Invalid saga ID provided")
+                        Timber.e("Invalid saga ID provided")
                         return@withTimeout Result.failure()
                     }
 
@@ -57,36 +57,36 @@ class NotificationGenerationWorker
                             androidx.lifecycle.Lifecycle.State.STARTED,
                         )
                     ) {
-                        Log.w(TAG, "App is in foreground, aborting notification generation")
+                        Timber.w("App is in foreground, aborting notification generation")
                         return@withTimeout Result.success()
                     }
 
-                    Log.d(TAG, "Starting notification generation for saga: $sagaId")
+                    Timber.d("Starting notification generation for saga: $sagaId")
 
                     val sagaContent = sagaRepository.sagaDao().getSagaContent(sagaId).first()
                     if (sagaContent == null) {
-                        Log.e(TAG, "Saga not found: $sagaId")
+                        Timber.e("Saga not found: $sagaId")
                         return@withTimeout Result.failure()
                     }
 
                     if (sagaContent.data.isEnded) {
-                        Log.w(TAG, "Saga has ended, skipping notification: $sagaId")
+                        Timber.w("Saga has ended, skipping notification: $sagaId")
                         return@withTimeout Result.success()
                     }
 
                     if (sagaContent.characters.isEmpty()) {
-                        Log.e(TAG, "No characters found for saga: $sagaId")
+                        Timber.e("No characters found for saga: $sagaId")
                         return@withTimeout Result.failure()
                     }
 
                     if (sagaContent.flatMessages().isEmpty()) {
-                        Log.e(TAG, "No messages found for saga: $sagaId")
+                        Timber.e("No messages found for saga: $sagaId")
                         return@withTimeout Result.failure()
                     }
 
                     val rules =
                         remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: run {
-                            Log.e(TAG, "Failed to fetch narrative rules")
+                            Timber.e("Failed to fetch narrative rules")
                             return@withTimeout Result.failure()
                         }
 
@@ -176,20 +176,17 @@ class NotificationGenerationWorker
                         pendingIntent,
                     )
 
-                    Log.d(
-                        TAG,
-                        "Notification scheduled at: ${
+                    Timber.d("Notification scheduled at: ${
                             notification.scheduledTimestamp.formatDate(
                                 DateFormatOption.HOUR_MINUTE_DAY_OF_MONTH_YEAR,
                             )
-                        }",
-                    )
-                    Log.i(TAG, "Generated notification: $notification")
+                        }")
+                    Timber.i("Generated notification: $notification")
 
                     Result.success()
                 }
             } catch (e: Exception) {
-                Log.e(TAG, "Failed to generate notification", e)
+                Timber.e(e, "Failed to generate notification")
                 Result.retry()
             }
         }

--- a/app/src/main/java/com/ilustris/sagai/core/services/RemoteConfigService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/services/RemoteConfigService.kt
@@ -1,10 +1,10 @@
 package com.ilustris.sagai.core.services
 
-import android.util.Log
 import com.google.firebase.remoteconfig.FirebaseRemoteConfig
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.ilustris.sagai.core.narrative.NarrativeRules
+import timber.log.Timber
 
 class RemoteConfigService {
     private val firebaseRemoteConfig by lazy {
@@ -37,7 +37,7 @@ class RemoteConfigService {
             try {
                 Gson().fromJson<T>(jsonString, typeToken.type)
             } catch (e: Exception) {
-                Log.e("RemoteConfigService", "Error parsing json for $key: ${e.message}")
+                Timber.tag("RemoteConfigService").e("Error parsing json for $key: ${e.message}")
                 null
             }
         } else {
@@ -54,11 +54,11 @@ class RemoteConfigService {
         try {
             block().also {
                 if (logEnabled) {
-                    Log.d("RemoteConfigService", "\n$method($key) -> $it\n")
+                    Timber.tag("RemoteConfigService").d("\n$method($key) -> $it\n")
                 }
             }
         } catch (e: Exception) {
-            Log.e("RemoteConfigService", "Error on $method($key): ${e.message}")
+            Timber.tag("RemoteConfigService").e("Error on $method($key): ${e.message}")
             e.printStackTrace()
             null
         }

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsViewModel.kt
@@ -1,6 +1,5 @@
 package com.ilustris.sagai.features.characters.ui
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilustris.sagai.core.data.model.ImagePalette
@@ -147,7 +146,7 @@ class CharacterDetailsViewModel
                     }
                     if (it.data.image.isNotEmpty()) {
                         val palette = paletteUseCase.extractPalette(it.data.image)
-                        Log.d(javaClass.simpleName, "Extracted palette: ${palette.toAINormalize()}")
+                        Timber.d("Extracted palette: ${palette.toAINormalize()}")
                         imagePalette.value = palette.getSuccess()
                     } else {
                         imagePalette.value = null

--- a/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/presentation/NewSagaViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/presentation/NewSagaViewModel.kt
@@ -1,6 +1,5 @@
 package com.ilustris.sagai.features.newsaga.ui.presentation
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilustris.sagai.core.ai.model.GenreVisualConfig
@@ -35,6 +34,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import timber.log.Timber
 
 internal data class LoadingState(
     val message: String,
@@ -246,11 +246,8 @@ class NewSagaViewModel
                     is AgenticAction.UpdateSaga -> {
                         _lockedSaga.value?.let { current ->
 
-                            Log.d(
-                                javaClass.simpleName,
-                                "Updating character from ${current.toJsonFormat()} ",
-                            )
-                            Log.d(javaClass.simpleName, "Trying to edit ${action.toJsonFormat()}")
+                            Timber.d("Updating character from ${current.toJsonFormat()} ")
+                            Timber.d("Trying to edit ${action.toJsonFormat()}")
                             if (current.id == action.id) {
                                 val updated =
                                     current.copy(
@@ -268,15 +265,9 @@ class NewSagaViewModel
                                         }
                                     }
                                 updateFeedWithSaga(updated)
-                                Log.i(
-                                    javaClass.simpleName,
-                                    "onAgenticAction: Updated to ${updated.toJsonFormat()}",
-                                )
+                                Timber.i("onAgenticAction: Updated to ${updated.toJsonFormat()}")
                             } else {
-                                Log.e(
-                                    javaClass.simpleName,
-                                    "Saga ID mismatch: ${current.id} != ${action.id}",
-                                )
+                                Timber.e("Saga ID mismatch: ${current.id} != ${action.id}")
                             }
                         }
                     }
@@ -289,11 +280,8 @@ class NewSagaViewModel
 
                     is AgenticAction.UpdateCharacter -> {
                         _selectedBook.value?.let { book ->
-                            Log.d(
-                                javaClass.simpleName,
-                                "Updating character from ${book.toJsonFormat()} ",
-                            )
-                            Log.d(javaClass.simpleName, ": Trying to edit ${action.toJsonFormat()}")
+                            Timber.d("Updating character from ${book.toJsonFormat()} ")
+                            Timber.d(": Trying to edit ${action.toJsonFormat()}")
 
                             val updatedCharacters =
                                 book.characters.map {
@@ -576,11 +564,7 @@ class NewSagaViewModel
                         }
 
                         is SagaCreationState.Error -> {
-                            Log.e(
-                                javaClass.simpleName,
-                                "saveSaga: Error saving saga",
-                                state.error,
-                            )
+                            Timber.e(state.error, "saveSaga: Error saving saga")
                             _savingError.value =
                                 state.error.message ?: "Unknown error occurred while saving"
                             _isSaving.value = false

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -2,7 +2,6 @@ package com.ilustris.sagai.features.saga.chat.data.manager
 
 import android.content.Context
 import android.net.Uri
-import android.util.Log
 import com.ilustris.sagai.R
 import com.ilustris.sagai.core.ai.model.GeneratedContent
 import com.ilustris.sagai.core.ai.services.GenreConfigService
@@ -75,6 +74,7 @@ import java.io.File
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import timber.log.Timber
 
 class SagaContentManagerImpl
     @Inject
@@ -139,23 +139,20 @@ class SagaContentManagerImpl
 
         override fun setDebugMode(enabled: Boolean) {
             isDebugModeEnabled = enabled
-            Log.i(javaClass.simpleName, "Debug mode ${if (enabled) "enabled" else "disabled"}")
+            Timber.i("Debug mode ${if (enabled) "enabled" else "disabled"}")
         }
 
         override suspend fun setProcessing(bool: Boolean) {
             isProcessing.set(bool)
             setNarrativeProcessingStatus(bool)
-            Log.i(javaClass.simpleName, "Processing mode ${if (bool) "enabled" else "disabled"}")
+            Timber.i("Processing mode ${if (bool) "enabled" else "disabled"}")
         }
 
         override fun isInDebugMode(): Boolean = isDebugModeEnabled
 
         override suspend fun advanceNarrative(pendingAdvance: PendingAdvance) {
             val currentSaga = content.value ?: return
-            Log.d(
-                javaClass.simpleName,
-                "Manually advancing narrative: ${pendingAdvance.javaClass.simpleName}",
-            )
+            Timber.d("Manually advancing narrative: ${pendingAdvance.javaClass.simpleName}")
 
             var action: RequestResult<Any>? = null
             startProcessing {
@@ -239,7 +236,7 @@ class SagaContentManagerImpl
                         }
                     validatePostAction(currentSaga, step, action.success)
                 }?.onFailureAsync {
-                    Log.e(javaClass.simpleName, "Failed to advance narrative: ${it.message}")
+                    Timber.e("Failed to advance narrative: ${it.message}")
                     emitMilestone(null)
                 }
         }
@@ -272,7 +269,7 @@ class SagaContentManagerImpl
             sagaJob?.cancel()
             sagaJob =
                 managerScope.launch {
-                    Log.d(javaClass.simpleName, "Loading saga: $sagaId")
+                    Timber.d("Loading saga: $sagaId")
                     content.value = null
                     try {
                         if (loadingObserverJob == null || loadingObserverJob?.isActive == false) {
@@ -305,25 +302,15 @@ class SagaContentManagerImpl
                                             "⚠️ Failed to load story data: ${e.message}"
                                         }
                                     }
-                                Log.e(
-                                    javaClass.simpleName,
-                                    "loadSaga: Room Flow error for saga $sagaId — ${e.message}",
-                                    e,
-                                )
+                                Timber.e(e, "loadSaga: Room Flow error for saga $sagaId — ${e.message}")
                                 updateSnackBar(snackBar(readableMessage))
                                 content.value = null
                                 setNarrativeProcessingStatus(false)
                             }.collectLatest { saga ->
-                                Log.d(
-                                    javaClass.simpleName,
-                                    "Saga flow updated for saga -> $sagaId",
-                                )
+                                Timber.d("Saga flow updated for saga -> $sagaId")
 
                                 if (saga == null) {
-                                    Log.e(
-                                        javaClass.simpleName,
-                                        "loadSaga: Unexpected error loading saga($sagaId)",
-                                    )
+                                    Timber.e("loadSaga: Unexpected error loading saga($sagaId)")
                                     content.emit(null)
                                     return@collectLatest
                                 }
@@ -340,10 +327,7 @@ class SagaContentManagerImpl
                                     previousSaga.acts == saga.acts &&
                                     previousSaga.characters == saga.characters
                                 ) {
-                                    Log.d(
-                                        javaClass.simpleName,
-                                        "Saga update was only playtime. Skipping narrative check.",
-                                    )
+                                    Timber.d("Saga update was only playtime. Skipping narrative check.")
                                     return@collectLatest
                                 }
 
@@ -417,7 +401,7 @@ class SagaContentManagerImpl
                                 }
                             }
                     } catch (e: Exception) {
-                        Log.e(javaClass.simpleName, "Error loading saga $sagaId", e)
+                        Timber.e(e, "Error loading saga $sagaId")
                         content.value = null
                         setNarrativeProcessingStatus(false)
                         emitMilestone(null)
@@ -468,7 +452,7 @@ class SagaContentManagerImpl
             val fileUrl = genreConfigService.getGenreConfig(genre).ambientMusicUrl
 
             if (fileUrl.isEmpty()) {
-                Log.e(javaClass.simpleName, "getAmbienceMusic: Invalid URL for ${genre.name}")
+                Timber.e("getAmbienceMusic: Invalid URL for ${genre.name}")
                 return
             }
 
@@ -495,7 +479,7 @@ class SagaContentManagerImpl
                     ),
                 )
             } else {
-                Log.d(javaClass.simpleName, "Debug message: $message")
+                Timber.d("Debug message: $message")
             }
         }
 
@@ -586,15 +570,9 @@ class SagaContentManagerImpl
                                 if (timelineContent.updatedWikis.isEmpty()) {
                                     wikiUseCase.generateWiki(saga, timelineContent.data)
                                 }
-                                Log.i(
-                                    javaClass.simpleName,
-                                    "Nickname analysis completed successfully.",
-                                )
+                                Timber.i("Nickname analysis completed successfully.")
                             } catch (e: Exception) {
-                                Log.e(
-                                    javaClass.simpleName,
-                                    "Error during nickname analysis: ${e.message}",
-                                )
+                                Timber.e("Error during nickname analysis: ${e.message}")
                                 e.printStackTrace()
                             }
                         }
@@ -611,10 +589,10 @@ class SagaContentManagerImpl
 
         override suspend fun backupSaga() {
             val currentSaga = content.value ?: return
-            Log.d(javaClass.simpleName, "Backing up saga ${currentSaga.data.id}")
+            Timber.d("Backing up saga ${currentSaga.data.id}")
 
             val backup = sagaHistoryUseCase.backupSaga(currentSaga)
-            Log.d(javaClass.simpleName, "backupSaga: backup successfull? ${backup.isSuccess}")
+            Timber.d("backupSaga: backup successfull? ${backup.isSuccess}")
         }
 
         override suspend fun enableBackup(uri: Uri?) {
@@ -724,15 +702,9 @@ class SagaContentManagerImpl
         private suspend fun updateAct(currentAct: ActContent) =
             executeRequest {
                 val saga = content.value!!
-                Log.d(
-                    javaClass.simpleName,
-                    "updating act(${saga.currentActInfo?.data?.id})",
-                )
+                Timber.d("updating act(${saga.currentActInfo?.data?.id})")
                 if (isDebugModeEnabled) {
-                    Log.i(
-                        javaClass.simpleName,
-                        "[DEBUG MODE] Generating fake act update data for saga ${saga.data.id}",
-                    )
+                    Timber.i("[DEBUG MODE] Generating fake act update data for saga ${saga.data.id}")
                     GeneratedContent(
                         Act(
                             id = currentAct.data.id,
@@ -798,9 +770,9 @@ class SagaContentManagerImpl
         private fun observeMilestone() =
             managerScope.launch {
                 milestoneUpdate.collectLatest {
-                    Log.d(javaClass.simpleName, "observeMilestone:\n$it")
+                    Timber.d("observeMilestone:\n$it")
                     if (it == null) {
-                        Log.i(javaClass.simpleName, "observeMilestone: No milestone checking story...")
+                        Timber.i("observeMilestone: No milestone checking story...")
                         checkNarrativeProgression(content.value)
                         return@collectLatest
                     }
@@ -810,7 +782,7 @@ class SagaContentManagerImpl
         private fun observeLoading() =
             managerScope.launch {
                 narrativeProcessingUiState.collectLatest {
-                    Log.d(javaClass.simpleName, "observeLoading: $it")
+                    Timber.d("observeLoading: $it")
                     if (it.not() && milestoneUpdate.value == null) {
                         checkNarrativeProgression(content.value)
                     }
@@ -823,18 +795,12 @@ class SagaContentManagerImpl
         ) {
             managerScope.launch {
                 if (progressionMutex.isLocked) {
-                    Log.i(
-                        javaClass.simpleName,
-                        "checkNarrativeProgression: already in progress, skipping.",
-                    )
+                    Timber.i("checkNarrativeProgression: already in progress, skipping.")
                     return@launch
                 }
 
                 if (isOnboardingVisible.value) {
-                    Log.i(
-                        javaClass.simpleName,
-                        "checkNarrativeProgression: onboarding visible, skipping.",
-                    )
+                    Timber.i("checkNarrativeProgression: onboarding visible, skipping.")
                     return@launch
                 }
 
@@ -842,25 +808,16 @@ class SagaContentManagerImpl
                     val currentSaga = content.value ?: saga ?: return@withLock
 
                     if (isProcessingNarrative.get() || isProcessing.get()) {
-                        Log.i(
-                            javaClass.simpleName,
-                            "Narrative check: currently processing, skipping recursive check.",
-                        )
+                        Timber.i("Narrative check: currently processing, skipping recursive check.")
                         return@withLock
                     }
 
                     if (milestoneUpdate.value != null && milestoneUpdate.value !is SagaMilestone.Loading) {
-                        Log.i(
-                            javaClass.simpleName,
-                            "checkNarrativeProgression: milestone active waiting for user interaction",
-                        )
+                        Timber.i("checkNarrativeProgression: milestone active waiting for user interaction")
                         return@withLock
                     }
 
-                    Log.d(
-                        javaClass.simpleName,
-                        "Starting narrative progression check #${++progressionCounter}",
-                    )
+                    Timber.d("Starting narrative progression check #${++progressionCounter}")
 
                     if (currentSaga.mainCharacter == null && isDebugModeEnabled) {
                         generateCharacter("Main Debug Character").onSuccessAsync { newCharacter ->
@@ -871,10 +828,7 @@ class SagaContentManagerImpl
 
                     val narrativeStep =
                         NarrativeCheck.validateProgression(currentSaga, fetchNarrativeRules())
-                    Log.d(
-                        javaClass.simpleName,
-                        "checkNarrativeProgression: Step ${narrativeStep.javaClass.simpleName}",
-                    )
+                    Timber.d("checkNarrativeProgression: Step ${narrativeStep.javaClass.simpleName}")
 
                     if (narrativeStep == NarrativeStep.NoActionNeeded) {
                         setProcessing(false)
@@ -897,10 +851,7 @@ class SagaContentManagerImpl
                                 is NarrativeStep.GenerateChapterIntroduction,
                                 is NarrativeStep.StartTimeline,
                                 -> {
-                                    Log.i(
-                                        javaClass.simpleName,
-                                        "checkNarrativeProgression: Milestone ${narrativeStep.javaClass.simpleName} detected. Waiting for user interaction.",
-                                    )
+                                    Timber.i("checkNarrativeProgression: Milestone ${narrativeStep.javaClass.simpleName} detected. Waiting for user interaction.")
                                     setProcessing(false)
                                     return@startProcessing
                                 }
@@ -959,7 +910,7 @@ class SagaContentManagerImpl
 
         private suspend fun skipNarrative() =
             executeRequest {
-                Log.i(javaClass.simpleName, "skipNarrative: No action needed skipping narrative")
+                Timber.i("skipNarrative: No action needed skipping narrative")
             }
 
         override val isMilestoneActive = MutableStateFlow(false)
@@ -985,15 +936,12 @@ class SagaContentManagerImpl
 
             // Prevent restarting if already processing
             if (isProcessing.get()) {
-                Log.d(javaClass.simpleName, "Already processing milestone, ignoring continue request")
+                Timber.d("Already processing milestone, ignoring continue request")
                 dismissMilestone()
                 return
             }
 
-            Log.d(
-                javaClass.simpleName,
-                "User continued from milestone: ${milestone.javaClass.simpleName}",
-            )
+            Timber.d("User continued from milestone: ${milestone.javaClass.simpleName}")
 
             startProcessing {
                 when (milestone) {
@@ -1046,9 +994,9 @@ class SagaContentManagerImpl
         ) {
             try {
                 if (isMilestoneActive.value) {
-                    Log.d(javaClass.simpleName, "Waiting for milestone dismissal...")
+                    Timber.d("Waiting for milestone dismissal...")
                     isMilestoneActive.first { !it }
-                    Log.d(javaClass.simpleName, "Milestone dismissed, resuming narrative.")
+                    Timber.d("Milestone dismissed, resuming narrative.")
                     proceedWithPostAction(saga, step, result)
                 } else {
                     proceedWithPostAction(saga, step, result)
@@ -1065,7 +1013,7 @@ class SagaContentManagerImpl
             step: NarrativeStep,
             result: RequestResult.Success<Any>,
         ) {
-            Log.d(javaClass.simpleName, "validatePostAction: performing next step $step")
+            Timber.d("validatePostAction: performing next step $step")
             when (step) {
                 is NarrativeStep.StartAct -> {
                     (result.value as? Act)?.let { data ->
@@ -1230,7 +1178,7 @@ class SagaContentManagerImpl
                                     ).not()
                         }
 
-                    Log.w(javaClass.simpleName, "Invalid events -> ${invalidEvents.size} ")
+                    Timber.w("Invalid events -> ${invalidEvents.size} ")
 
                     invalidEvents.forEach {
                         timelineUseCase.deleteTimeline(it.data)
@@ -1336,10 +1284,7 @@ class SagaContentManagerImpl
                 try {
                     val currentSaga = content.value!!
                     if (isDebugModeEnabled) {
-                        Log.i(
-                            javaClass.simpleName,
-                            "[DEBUG MODE] Generating fake character for saga ${currentSaga.data.id}",
-                        )
+                        Timber.i("[DEBUG MODE] Generating fake character for saga ${currentSaga.data.id}")
                         val fakeCharacter =
                             Character(
                                 name = "Fake Character: $description",
@@ -1420,10 +1365,7 @@ class SagaContentManagerImpl
                 try {
                     val currentSaga = content.value!!
                     if (isDebugModeEnabled) {
-                        Log.i(
-                            javaClass.simpleName,
-                            "[DEBUG MODE] Skipping image generation for character ${character.name}",
-                        )
+                        Timber.i("[DEBUG MODE] Skipping image generation for character ${character.name}")
                         emitMilestone(null)
                         character
                     } else {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
-import android.util.Log
 import android.util.LruCache
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.DefaultLifecycleObserver
@@ -60,6 +59,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.time.Duration.Companion.seconds
+import timber.log.Timber
 
 @OptIn(PublicPreviewAPI::class)
 @HiltViewModel
@@ -570,10 +570,7 @@ class ChatViewModel
                             old.relationships == new.relationships
                     }.collectLatest { sagaContent ->
 
-                        Log.d(
-                            "ChatViewModel",
-                            "observeSaga triggered for genre: ${sagaContent?.data?.genre}",
-                        )
+                        Timber.tag("ChatViewModel").d("observeSaga triggered for genre: ${sagaContent?.data?.genre}")
                         if (sagaContent == null) {
                             if (loadFinished) {
                                 updateLoading(false)
@@ -585,15 +582,12 @@ class ChatViewModel
                         // Fetch visual config for current genre
                         val visualConfig =
                             visualConfigService.getVisualConfig(sagaContent.data.genre)
-                        Log.d("ChatViewModel", "Fetched visual config: $visualConfig")
+                        Timber.tag("ChatViewModel").d("Fetched visual config: $visualConfig")
                         stateManager.updateVisualConfig(visualConfig)
 
                         val rules =
                             remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: run {
-                                Log.e(
-                                    this@ChatViewModel.javaClass.simpleName,
-                                    "observeSaga: Couldn't fetch rules",
-                                )
+                                Timber.tag(this@ChatViewModel.javaClass.simpleName).e("observeSaga: Couldn't fetch rules")
                                 return@collectLatest
                             }
 
@@ -719,10 +713,7 @@ class ChatViewModel
                     musicFile
                 }.collectLatest { musicFile ->
                     if (musicFile != null && musicFile.exists()) {
-                        Log.d(
-                            "ChatViewModel",
-                            "Ambient music available. Instructing SagaPlaybackService to play: ${musicFile.absolutePath}",
-                        )
+                        Timber.tag("ChatViewModel").d("Ambient music available. Instructing SagaPlaybackService to play: ${musicFile.absolutePath}")
                         val musicIntent =
                             Intent(context, SagaPlaybackService::class.java).apply {
                                 action = SagaPlaybackService.ACTION_START
@@ -733,10 +724,7 @@ class ChatViewModel
                             }
                         context.startService(musicIntent)
                     } else {
-                        Log.d(
-                            "ChatViewModel",
-                            "Music file not available. Instructing SagaPlaybackService to stop.",
-                        )
+                        Timber.tag("ChatViewModel").d("Music file not available. Instructing SagaPlaybackService to stop.")
                         context.startService(
                             Intent(context, SagaPlaybackService::class.java).apply {
                                 action = SagaPlaybackService.ACTION_STOP
@@ -752,7 +740,7 @@ class ChatViewModel
             super.onResume(owner)
             startTime = System.currentTimeMillis()
             scheduledNotificationService.cancelScheduledNotifications()
-            Log.d("ChatViewModel", "Lifecycle: onResume. Informing service to resume.")
+            Timber.tag("ChatViewModel").d("Lifecycle: onResume. Informing service to resume.")
             context.startService(
                 Intent(context, SagaPlaybackService::class.java).apply {
                     action = SagaPlaybackService.ACTION_RESUME
@@ -777,7 +765,7 @@ class ChatViewModel
 
         override fun onPause(owner: LifecycleOwner) {
             super.onPause(owner)
-            Log.d("ChatViewModel", "Lifecycle: onPause called. Informing service to pause.")
+            Timber.tag("ChatViewModel").d("Lifecycle: onPause called. Informing service to pause.")
             context.startService(
                 Intent(context, SagaPlaybackService::class.java).apply {
                     action = SagaPlaybackService.ACTION_PAUSE
@@ -790,10 +778,7 @@ class ChatViewModel
                     val duration = endTime - startTime
                     val currentSaga = uiState.value.sagaContent
                     if (currentSaga != null && duration > 0) {
-                        Log.d(
-                            "ChatViewModel",
-                            "Updating playtime for saga ${currentSaga.data.id}: +${duration}ms",
-                        )
+                        Timber.tag("ChatViewModel").d("Updating playtime for saga ${currentSaga.data.id}: +${duration}ms")
                         sagaContentManager.updatePlaytime(currentSaga.data.id, duration)
                     }
                     startTime = 0L
@@ -804,7 +789,7 @@ class ChatViewModel
 
         override fun onCleared() {
             super.onCleared()
-            Log.d("ChatViewModel", "onCleared called. Killing music service.")
+            Timber.tag("ChatViewModel").d("onCleared called. Killing music service.")
             context.startService(
                 Intent(context, SagaPlaybackService::class.java).apply {
                     action = SagaPlaybackService.ACTION_STOP
@@ -869,10 +854,7 @@ class ChatViewModel
                 return
             }
 
-            Log.d(
-                javaClass.simpleName,
-                "Smart Suggestions status: ${uiState.value.smartSuggestionsEnabled}",
-            )
+            Timber.d("Smart Suggestions status: ${uiState.value.smartSuggestionsEnabled}")
 
             viewModelScope.launch(Dispatchers.IO) {
                 if (userConfirmed || uiState.value.smartSuggestionsEnabled.not()) {
@@ -1104,10 +1086,7 @@ class ChatViewModel
 
                 delay(5.seconds)
 
-                Log.d(
-                    javaClass.simpleName,
-                    "generateSuggestions: checking if is generating -> ${uiState.value.isGenerating}",
-                )
+                Timber.d("generateSuggestions: checking if is generating -> ${uiState.value.isGenerating}")
                 if (uiState.value.isGenerating || uiState.value.isLoading) {
                     return@launch
                 }
@@ -1264,7 +1243,7 @@ class ChatViewModel
         private fun enableDebugMode(enabled: Boolean) {
             sagaContentManager.setDebugMode(enabled)
             messageUseCase.setDebugMode(enabled)
-            Log.i("ChatViewModel", "Debug mode set to: $enabled")
+            Timber.tag("ChatViewModel").i("Debug mode set to: $enabled")
         }
 
         fun sendFakeUserMessages(count: Int) {
@@ -1289,7 +1268,7 @@ class ChatViewModel
                     sendMessage(fakeUserMessage, false, null, false)
                     delay(100)
                 }
-                Log.d("ChatViewModel", "Finished enqueuing $count fake messages.")
+                Timber.tag("ChatViewModel").d("Finished enqueuing $count fake messages.")
             }
         }
 
@@ -1390,7 +1369,7 @@ class ChatViewModel
                     startProgressUpdates(messageId)
                 },
                 onError = { exception ->
-                    Log.e("ChatViewModel", "Audio playback error", exception)
+                    Timber.tag("ChatViewModel").e(exception, "Audio playback error")
                     viewModelScope.launch(Dispatchers.Main) {
                         stateManager.updateState { it.copy(audioPlaybackState = null) }
                     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/repository/MessageRepositoryImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/repository/MessageRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package com.ilustris.sagai.features.saga.chat.repository
 
-import android.util.Log
 import com.ilustris.sagai.core.database.SagaDatabase
 import com.ilustris.sagai.core.utils.toJsonFormat
 import com.ilustris.sagai.features.saga.chat.data.model.Message
 import com.ilustris.sagai.features.saga.datasource.MessageDao
 import javax.inject.Inject
+import timber.log.Timber
 
 class MessageRepositoryImpl
     @Inject
@@ -19,7 +19,7 @@ class MessageRepositoryImpl
         override suspend fun getMessages(sagaId: Int) = messageDao.getMessages(sagaId)
 
         override suspend fun saveMessage(message: Message): Message {
-            Log.d(javaClass.simpleName, "saveMessage: Saving\n${message.toJsonFormat()}")
+            Timber.d("saveMessage: Saving\n${message.toJsonFormat()}")
             return message.copy(
                 id =
                     messageDao

--- a/app/src/main/java/com/ilustris/sagai/features/timeline/domain/TimelineUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/timeline/domain/TimelineUseCaseImpl.kt
@@ -1,6 +1,5 @@
 package com.ilustris.sagai.features.timeline.domain
 
-import android.util.Log
 import com.ilustris.sagai.core.ai.GemmaClient
 import com.ilustris.sagai.core.ai.prompts.ChatPrompts
 import com.ilustris.sagai.core.ai.prompts.TimelinePrompts
@@ -20,6 +19,7 @@ import com.ilustris.sagai.features.timeline.data.repository.TimelineRepository
 import com.ilustris.sagai.features.wiki.data.usecase.EmotionalUseCase
 import com.ilustris.sagai.features.wiki.data.usecase.WikiUseCase
 import javax.inject.Inject
+import timber.log.Timber
 
 class TimelineUseCaseImpl
     @Inject
@@ -399,7 +399,7 @@ class TimelineUseCaseImpl
             saga: SagaContent,
         ) = executeRequest {
             val wikisToUpdateOrAdd = wikiUseCase.generateWiki(saga, timeline).getSuccess()!!
-            Log.d(javaClass.simpleName, "updateWikis: Updating wikis $wikisToUpdateOrAdd")
+            Timber.d("updateWikis: Updating wikis $wikisToUpdateOrAdd")
             wikisToUpdateOrAdd.forEach { generatedWiki ->
                 val existingWiki =
                     saga.wikis.find { wiki ->
@@ -412,10 +412,7 @@ class TimelineUseCaseImpl
                             )
                     }
                 if (existingWiki != null) {
-                    Log.d(
-                        javaClass.simpleName,
-                        "Updating existing wiki: ${existingWiki.title} (ID: ${existingWiki.id}) for saga ${saga.data.id}",
-                    )
+                    Timber.d("Updating existing wiki: ${existingWiki.title} (ID: ${existingWiki.id}) for saga ${saga.data.id}")
                     wikiUseCase.updateWiki(
                         generatedWiki.copy(
                             id = existingWiki.id,
@@ -424,10 +421,7 @@ class TimelineUseCaseImpl
                         ),
                     )
                 } else {
-                    Log.d(
-                        javaClass.simpleName,
-                        "Saving new wiki: ${generatedWiki.title} for saga ${saga.data.id}",
-                    )
+                    Timber.d("Saving new wiki: ${generatedWiki.title} for saga ${saga.data.id}")
                     wikiUseCase.saveWiki(
                         generatedWiki.copy(
                             sagaId = saga.data.id,
@@ -437,10 +431,7 @@ class TimelineUseCaseImpl
                 }
             }
             if (wikisToUpdateOrAdd.isEmpty()) {
-                Log.i(
-                    javaClass.simpleName,
-                    "updateWikis: No wiki updates generated for recnt events in saga ${saga.data.id}.",
-                )
+                Timber.i("updateWikis: No wiki updates generated for recnt events in saga ${saga.data.id}.")
             }
         }
 

--- a/app/src/main/java/com/ilustris/sagai/features/wiki/data/usecase/WikiUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/wiki/data/usecase/WikiUseCaseImpl.kt
@@ -1,6 +1,5 @@
 package com.ilustris.sagai.features.wiki.data.usecase
 
-import android.util.Log
 import com.ilustris.sagai.core.ai.GemmaClient
 import com.ilustris.sagai.core.ai.prompts.WikiPrompts
 import com.ilustris.sagai.core.ai.services.GenreConfigService
@@ -13,6 +12,7 @@ import com.ilustris.sagai.features.wiki.data.model.Wiki
 import com.ilustris.sagai.features.wiki.data.model.WikiGen
 import com.ilustris.sagai.features.wiki.data.repository.WikiRepository
 import javax.inject.Inject
+import timber.log.Timber
 
 class WikiUseCaseImpl
     @Inject
@@ -76,10 +76,7 @@ class WikiUseCaseImpl
                     mergedWikis.filter { mergedItem ->
                         // Skip items with no merge candidate (secondItem is null or empty)
                         if (mergedItem.secondItem.isNullOrBlank()) {
-                            Log.d(
-                                javaClass.simpleName,
-                                "Skipping item with no merge candidate: ${mergedItem.firstItem}",
-                            )
+                            Timber.d("Skipping item with no merge candidate: ${mergedItem.firstItem}")
                             return@filter false
                         }
 
@@ -116,6 +113,6 @@ class WikiUseCaseImpl
                     }
                 }
 
-                Log.d(javaClass.simpleName, "mergeWikis: Updated ${validItems.size} items")
+                Timber.d("mergeWikis: Updated ${validItems.size} items")
             }
     }

--- a/app/src/main/java/com/ilustris/sagai/ui/theme/components/mascot/MascotEmotionFace.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/theme/components/mascot/MascotEmotionFace.kt
@@ -1,6 +1,5 @@
 package com.ilustris.sagai.ui.theme.components.mascot
 
-import android.util.Log
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.EaseInBounce
 import androidx.compose.animation.core.tween
@@ -12,6 +11,7 @@ import com.ilustris.sagai.features.saga.chat.data.model.EmotionalTone
 import com.ilustris.sagai.ui.theme.components.VibeShapeDrawing
 import com.ilustris.sagai.ui.theme.levitate
 import kotlin.time.Duration.Companion.seconds
+import timber.log.Timber
 
 @Composable
 fun MascotEmotionFace(
@@ -39,7 +39,7 @@ fun MascotEmotionFace(
                             enter = scaleIn(tween(600, easing = EaseInBounce)),
                         ),
                 onError = {
-                    Log.e("MascotSticker", "Error loading image $url")
+                    Timber.tag("MascotSticker").e("Error loading image $url")
                     it.result.throwable.printStackTrace()
                 },
             )

--- a/app/src/main/java/com/ilustris/sagai/ui/theme/filters/SelectiveColorHighlightEffect.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/theme/filters/SelectiveColorHighlightEffect.kt
@@ -3,7 +3,6 @@ package com.ilustris.sagai.ui.theme.filters
 import android.graphics.RenderEffect
 import android.graphics.RuntimeShader
 import android.os.Build
-import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -73,10 +72,7 @@ fun Modifier.selectiveColorHighlight(
     shaderAssetFileName: String = "selective_color_highlight.agsl",
 ): Modifier {
     LaunchedEffect(Unit) {
-        Log.d(
-            "SelectiveColor",
-            "selectiveColorHighlight modifier called with params present: ${params != null}",
-        )
+        Timber.tag("SelectiveColor").d("selectiveColorHighlight modifier called with params present: ${params != null}")
     }
     if (params == null) return this
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {


### PR DESCRIPTION
I have replaced all instances of `android.util.Log` with `timber.log.Timber` across the codebase. This includes:
- Updating imports to use `timber.log.Timber`.
- Converting `Log.d`, `Log.i`, `Log.w`, and `Log.e` calls to their Timber equivalents.
- Properly handling exception logging by ensuring `Throwable` is the first argument in `Timber.e`.
- Leveraging Timber's automatic tagging where appropriate and using `.tag()` when a specific tag was required.

---
*PR created automatically by Jules for task [12178370764020478567](https://jules.google.com/task/12178370764020478567) started by @CaioProgramming*