### PR TITLE
fix: 1.10.1 — Saga ambient music & genre VFX on entry

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/core/theme/SagaThemeManager.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/theme/SagaThemeManager.kt
@@ -60,6 +60,9 @@ class SagaThemeManager
 
         private var isNeutralScreen: Boolean = true
 
+        /** Genre requested while still on a neutral screen (Home, etc.) — applied when leaving neutral. */
+        private var pendingGenre: Genre? = null
+
         /**
          * Updates the neutrality state of the manager.
          * When neutral, any attempt to set a genre is ignored, and the theme is reset.
@@ -67,32 +70,55 @@ class SagaThemeManager
         fun setNeutral(isNeutral: Boolean) {
             this.isNeutralScreen = isNeutral
             if (isNeutral) {
+                pendingGenre = null
                 resetTheme()
+            } else {
+                pendingGenre?.let { genre ->
+                    pendingGenre = null
+                    updateTheme(genre)
+                }
             }
         }
 
-        /** Set the active genre. The root theme will animate to its colors and fetch configurations. */
-        fun updateTheme(genre: Genre?) {
+        /**
+         * Set the active genre. Fetches ambient music and reply SFX from Remote Config.
+         * @param playEntryVfx When true, plays genre SFX + haptics after configs are loaded (screen entry).
+         */
+        fun updateTheme(
+            genre: Genre?,
+            playEntryVfx: Boolean = false,
+        ) {
             if (isNeutralScreen && genre != null) {
-                Timber.w("Theme update ignored: currently on a neutral screen (Home, Profile, etc.)")
+                pendingGenre = genre
+                Timber.d("SagaThemeManager: Theme queued for $genre (neutral screen)")
                 return
             }
-            if (_currentGenre.value == genre && genre != null) return
+            pendingGenre = null
+
+            val sameGenre = _currentGenre.value == genre && genre != null
+            val needsMediaRefresh = _ambientMusicFile.value == null
+            if (sameGenre && !needsMediaRefresh && !playEntryVfx) return
 
             _currentGenre.value = genre
             if (genre != null) {
                 managerScope.launch {
-                    fetchConfigs(genre)
+                    fetchConfigs(genre, playEntryVfx)
                 }
             } else {
                 resetTheme()
             }
         }
 
-        private suspend fun fetchConfigs(genre: Genre) {
+        private suspend fun fetchConfigs(
+            genre: Genre,
+            playEntryVfx: Boolean = false,
+        ) {
             try {
                 getAmbienceMusic(genre)
                 getReplySfx(genre)
+                if (playEntryVfx) {
+                    playVfxInternal()
+                }
             } catch (e: Exception) {
                 Timber.e(e, "SagaThemeManager: Error fetching media configs for $genre")
             }
@@ -129,14 +155,22 @@ class SagaThemeManager
 
         /** Triggers the current genre's VFX (sound + vibration pattern from visual config). */
         fun playVfx() {
-            val genre = _currentGenre.value ?: return
-            managerScope.launch {
-                delay(300)
-                val visual = visualConfigService.getVisualConfig(genre)
-                val pattern = genre.vibrationPattern(visual)
-                soundFxService.playWithHaptics(pattern)
-                _vfxTrigger.emit(Unit)
+            if (_currentGenre.value == null) {
+                Timber.w("SagaThemeManager: playVfx skipped — no active genre")
+                return
             }
+            managerScope.launch {
+                playVfxInternal()
+            }
+        }
+
+        private suspend fun playVfxInternal() {
+            val genre = _currentGenre.value ?: return
+            delay(300)
+            val visual = visualConfigService.getVisualConfig(genre)
+            val pattern = genre.vibrationPattern(visual)
+            soundFxService.playWithHaptics(pattern)
+            _vfxTrigger.emit(Unit)
         }
 
         /** Clear the active genre, reverting to the default brand identity. */

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -53,6 +53,8 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
@@ -84,6 +86,9 @@ class ChatViewModel
         private val stateManager = ChatStateManager()
         val uiState = stateManager.uiState
 
+        private val _genreVfxPulse = MutableStateFlow(false)
+        val genreVfxPulse = _genreVfxPulse.asStateFlow()
+
         val segmentedImageCache = LruCache<String, Bitmap?>(5 * 1024 * 1024)
         private var audioProgressJob: kotlinx.coroutines.Job? = null
         private val audioMediaPlayerManager: MediaPlayerManager = MediaPlayerManagerImpl(context)
@@ -112,7 +117,13 @@ class ChatViewModel
         private var narrativeObserverJob: kotlinx.coroutines.Job? = null
 
         init {
-            // State initialized by ChatStateManager
+            viewModelScope.launch {
+                sagaThemeManager.vfxTrigger.collect {
+                    _genreVfxPulse.value = true
+                    delay(2.seconds)
+                    _genreVfxPulse.value = false
+                }
+            }
         }
 
         fun handleAction(action: ChatUiAction) {
@@ -637,7 +648,11 @@ class ChatViewModel
                             return@collectLatest
                         }
 
-                        sagaThemeManager.updateTheme(sagaContent.data.genre)
+                        val isFirstLoad = !loadFinished
+                        sagaThemeManager.updateTheme(
+                            sagaContent.data.genre,
+                            playEntryVfx = isFirstLoad,
+                        )
 
                         val rules =
                             remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: run {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -200,6 +200,7 @@ fun ChatView(
     animatedVisibilityScope: AnimatedContentScope,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val genreVfxPulse by viewModel.genreVfxPulse.collectAsStateWithLifecycle()
     val context = LocalActivity.current
     val activity = LocalActivity.current
     var requiredPermission by remember { mutableStateOf<String?>(null) }
@@ -300,6 +301,7 @@ fun ChatView(
                                         onAction = onAction,
                                         padding = padding,
                                         isDebug = isDebug,
+                                        genreVfxPulse = genreVfxPulse,
                                         sharedTransitionScope = sharedTransitionScope,
                                         animatedVisibilityScope = animatedVisibilityScope,
                                     )
@@ -431,6 +433,7 @@ fun ChatContent(
     onAction: (ChatUiAction) -> Unit,
     padding: PaddingValues = PaddingValues(),
     isDebug: Boolean = false,
+    genreVfxPulse: Boolean = false,
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedContentScope,
 ) {
@@ -890,7 +893,10 @@ fun ChatContent(
                                     Modifier
                                         .genreVfx(
                                             saga.genre,
-                                            isPlaying = uiState.isGenerating || uiState.isLoading,
+                                            isPlaying =
+                                                uiState.isGenerating ||
+                                                    uiState.isLoading ||
+                                                    genreVfxPulse,
                                         )
                                         .size(32.dp)
                                         .clip(CircleShape)

--- a/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
@@ -84,21 +84,11 @@ class SagaDetailViewModel
                                     cachedSegmentedImage = section.segmentedImage
                                     section
                                 }
-                            if (_state.value !is State.Success) {
-                                playSoundFx()
-                            }
-
                             _state.value = State.Success(resume.saga)
                         }.onFailureAsync {
                             _state.emit(State.Error(emptyString()))
                         }
                 }
-        }
-
-        private fun playSoundFx() {
-            viewModelScope.launch {
-                sagaThemeManager.playVfx()
-            }
         }
 
         fun handleAction(detailAction: DetailAction) {
@@ -128,7 +118,7 @@ class SagaDetailViewModel
                     sagaDetailUseCase.getSagaResume(sagaId).collectLatest { resume ->
                         resume.let { data ->
                             this@SagaDetailViewModel.sagaResume.value = data
-                            sagaThemeManager.updateTheme(data.saga.genre)
+                            sagaThemeManager.updateTheme(data.saga.genre, playEntryVfx = true)
 
                             loadInitialSection()
                             detailDrawer.value =

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 # Version components following MAJOR.MINOR.PATCH convention
 MAJOR=1
 MINOR=10
-PATCH=0
+PATCH=1


### PR DESCRIPTION
## Summary

Hotfix for missing ambient music and genre VFX (sound + haptics + visual pulse) when entering a saga or showing milestones.

- **SagaThemeManager**: Queue theme while on neutral screens (Home); apply when entering Chat/Saga Detail. Refetch ambient music if cleared after leaving Home. `playEntryVfx` plays SFX after Remote Config media loads.
- **Chat**: Entry sting on first saga load; `genreVfxPulse` on milestone via `vfxTrigger`.
- **Saga Detail**: `updateTheme(..., playEntryVfx = true)` on saga open.

## Version

`1.10.0` → `1.10.1` (`version.properties`)

## Test plan

- [ ] Open saga from Home → ambient music starts in Chat
- [ ] Open saga detail → music + entry VFX play
- [ ] Trigger intrusive milestone → SFX/haptics + brief icon animation in Chat
- [ ] Return to Home → music stops; re-enter same saga → music and VFX work again
- [ ] Tap notification deep link to open chat (already on same saga) → no duplicate navigation


Made with [Cursor](https://cursor.com)