### PR TITLE
fix: dedupe genre SFX (1.10.2)

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/core/media/SoundFxService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/media/SoundFxService.kt
@@ -6,6 +6,7 @@ import android.media.AudioManager
 import android.media.SoundPool
 import android.os.Build
 import android.os.VibrationEffect
+import android.os.SystemClock
 import android.os.Vibrator
 import android.os.VibratorManager
 import timber.log.Timber
@@ -46,7 +47,27 @@ class SoundFxService(
 
     private var loadedSoundId: Int = 0
 
+    /** Prevents overlapping / back-to-back plays (entry VFX + milestone, rapid emits). */
+    private val playDebounceMs = 750L
+
+    @Volatile
+    private var lastPlayAtMs = 0L
+
+    private val playLock = Any()
+
     private fun isSoundPlaybackAllowed(): Boolean = audioManager.ringerMode != AudioManager.RINGER_MODE_SILENT
+
+    private fun tryAcquirePlaySlot(): Boolean {
+        synchronized(playLock) {
+            val now = SystemClock.elapsedRealtime()
+            if (now - lastPlayAtMs < playDebounceMs) {
+                Timber.tag(tag).d("play debounced (${now - lastPlayAtMs}ms since last)")
+                return false
+            }
+            lastPlayAtMs = now
+            return true
+        }
+    }
 
     fun prepare(file: File) {
         if (loadedSoundId != 0) soundPool.unload(loadedSoundId)
@@ -63,16 +84,8 @@ class SoundFxService(
     }
 
     fun play() {
-        if (loadedSoundId == 0) {
-            Timber.tag(tag).d("play() skipped — not loaded")
-            return
-        }
-        if (!isSoundPlaybackAllowed()) {
-            Timber.tag(tag).d("play() skipped — ringer silent")
-            return
-        }
-        val streamId = soundPool.play(loadedSoundId, 1f, 1f, 1, 0, 1f)
-        Timber.tag(tag).d(if (streamId == 0) "SFX not ready yet" else "SFX playing")
+        if (!tryAcquirePlaySlot()) return
+        playLoadedSound("play()")
     }
 
     fun vibrate(pattern: LongArray) {
@@ -87,8 +100,24 @@ class SoundFxService(
     }
 
     fun playWithHaptics(pattern: LongArray?) {
-        play()
-        pattern?.let { vibrate(it) }
+        if (!tryAcquirePlaySlot()) return
+        if (playLoadedSound("playWithHaptics")) {
+            pattern?.let { vibrate(it) }
+        }
+    }
+
+    private fun playLoadedSound(caller: String): Boolean {
+        if (loadedSoundId == 0) {
+            Timber.tag(tag).d("$caller skipped — not loaded")
+            return false
+        }
+        if (!isSoundPlaybackAllowed()) {
+            Timber.tag(tag).d("$caller skipped — ringer silent")
+            return false
+        }
+        val streamId = soundPool.play(loadedSoundId, 1f, 1f, 1, 0, 1f)
+        Timber.tag(tag).d(if (streamId == 0) "SFX not ready yet" else "SFX playing ($caller)")
+        return streamId != 0
     }
 
     fun release() {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -722,13 +722,12 @@ class SagaContentManagerImpl
 
         private fun emitMilestone(milestone: SagaMilestone?) =
             CoroutineScope(Dispatchers.Main.immediate).launch {
-                if (milestone != null &&
-                    milestone !is SagaMilestone.Loading &&
-                    milestone.isIntrusive
-                ) {
+                if (milestone != null && milestone.isIntrusive) {
                     isMilestoneActive.value = true
                     narrativeCoordinator.markMilestoneActive()
-                    sagaThemeManager.playVfx()
+                    if (milestone.shouldPlaySoundFx) {
+                        sagaThemeManager.playVfx()
+                    }
                 }
                 milestoneUpdate.emit(milestone)
             }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -648,11 +648,7 @@ class ChatViewModel
                             return@collectLatest
                         }
 
-                        val isFirstLoad = !loadFinished
-                        sagaThemeManager.updateTheme(
-                            sagaContent.data.genre,
-                            playEntryVfx = isFirstLoad,
-                        )
+                        sagaThemeManager.updateTheme(sagaContent.data.genre)
 
                         val rules =
                             remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: run {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/SagaMilestone.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/SagaMilestone.kt
@@ -94,6 +94,17 @@ sealed class SagaMilestone(
         delay = 0.seconds,
         isIntrusive = true,
     )
+
+    /** Whether this milestone should trigger genre SFX + haptics. */
+    val shouldPlaySoundFx: Boolean
+        get() =
+            when (this) {
+                is Loading,
+                is NewEvent,
+                is CurrentObjective,
+                -> false
+                else -> isIntrusive
+            }
 }
 
 enum class LoadingType {

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 # Version components following MAJOR.MINOR.PATCH convention
 MAJOR=1
 MINOR=10
-PATCH=1
+PATCH=2


### PR DESCRIPTION
## Summary
- Debounce `SoundFxService` (750ms) to prevent overlapping SFX streams
- Remove duplicate entry sound on chat open (`playEntryVfx` + resume `Introduction` milestone)
- Skip genre SFX on `NewEvent` milestones (routine AI timeline evolutions)

## Test plan
- [ ] Open saga chat — entry sound plays once (resume intro milestone)
- [ ] Receive AI replies — no SFX on each message
- [ ] Complete chapter/act — milestone SFX still plays
- [ ] Open saga detail — entry VFX still plays once


Made with [Cursor](https://cursor.com)