### PR TITLE
fix: stop clipping chat message text in AI prompts (1.10.3)

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/MainActivity.kt
+++ b/app/src/main/java/com/ilustris/sagai/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -51,6 +52,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation3.runtime.NavKey
@@ -60,10 +62,13 @@ import com.ilustris.sagai.core.data.SideEffect
 import com.ilustris.sagai.core.network.ConnectivityObserver
 import com.ilustris.sagai.core.network.ui.NoInternetScreen
 import com.ilustris.sagai.core.services.SideEffectService
+import com.ilustris.sagai.core.navigation.SagaNavigationTracker
+import com.ilustris.sagai.core.notifications.SagaNotificationRouter
 import com.ilustris.sagai.core.theme.SagaThemeManager
 import com.ilustris.sagai.features.onboarding.data.OnboardingType
 import com.ilustris.sagai.features.onboarding.ui.OnboardingDialog
 import com.ilustris.sagai.ui.components.BlurProvider
+import com.ilustris.sagai.ui.components.SagaInAppNotificationBanner
 import com.ilustris.sagai.ui.components.SagaSnackBar
 import com.ilustris.sagai.ui.navigation.AuditLogsKey
 import com.ilustris.sagai.ui.navigation.FAQKey
@@ -97,6 +102,12 @@ class MainActivity : ComponentActivity() {
 
     @Inject
     lateinit var sagaThemeManager: SagaThemeManager
+
+    @Inject
+    lateinit var sagaNotificationRouter: SagaNotificationRouter
+
+    @Inject
+    lateinit var sagaNavigationTracker: SagaNavigationTracker
 
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
@@ -145,11 +156,20 @@ class MainActivity : ComponentActivity() {
                 sagaThemeManager.setNeutral(isNeutralScreen)
             }
 
+            LaunchedEffect(currentKey) {
+                sagaNavigationTracker.update(currentKey)
+            }
+
+            LaunchedEffect(Unit) {
+                sagaNotificationRouter.start()
+            }
+
             SagAITheme(genre = themeGenre) {
                 Timber.d("MainActivity: SagAITheme block")
 
                 var activeSideEffect by remember { mutableStateOf<SideEffect?>(null) }
                 val globalSnackBar by sagaThemeManager.snackBarMessage.collectAsState()
+                val inAppNotification by sagaNotificationRouter.inAppNotification.collectAsState()
                 var showGenreTransition by remember { mutableStateOf(false) }
 
                 LaunchedEffect(currentGenre) {
@@ -304,6 +324,22 @@ class MainActivity : ComponentActivity() {
                                         NavDisplay(
                                             entries = navigationState.toEntries(entryProvider),
                                             onBack = { navigator.goBack() },
+                                        )
+
+                                        SagaInAppNotificationBanner(
+                                            notification = inAppNotification,
+                                            onOpen = { deepLink ->
+                                                navigateDeepLink(deepLink)
+                                                sagaNotificationRouter.dismissInApp()
+                                            },
+                                            onDismiss = { sagaNotificationRouter.dismissInApp() },
+                                            modifier =
+                                                Modifier
+                                                    .align(Alignment.TopCenter)
+                                                    .zIndex(2f)
+                                                    .statusBarsPadding()
+                                                    .padding(horizontal = 12.dp, vertical = 8.dp)
+                                                    .fillMaxWidth(),
                                         )
 
                                         SagaSnackBar(

--- a/app/src/main/java/com/ilustris/sagai/MainActivity.kt
+++ b/app/src/main/java/com/ilustris/sagai/MainActivity.kt
@@ -33,12 +33,16 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -163,9 +167,46 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
+                // Pause/resume ambient when the app backgrounds (not when Nav 3 swaps screens).
+                val lifecycleOwner = LocalLifecycleOwner.current
+                var hasAmbientTrack by remember { mutableStateOf(false) }
+                DisposableEffect(lifecycleOwner) {
+                    val observer =
+                        object : DefaultLifecycleObserver {
+                            override fun onPause(owner: LifecycleOwner) {
+                                if (!hasAmbientTrack) return
+                                startService(
+                                    Intent(
+                                        applicationContext,
+                                        com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
+                                    ).apply {
+                                        action =
+                                            com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_PAUSE
+                                    },
+                                )
+                            }
+
+                            override fun onResume(owner: LifecycleOwner) {
+                                if (!hasAmbientTrack) return
+                                startService(
+                                    Intent(
+                                        applicationContext,
+                                        com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
+                                    ).apply {
+                                        action =
+                                            com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_RESUME
+                                    },
+                                )
+                            }
+                        }
+                    lifecycleOwner.lifecycle.addObserver(observer)
+                    onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+                }
+
                 // Global Ambient Music Control
                 val ambientMusicFile by sagaThemeManager.ambientMusicFile.collectAsState()
                 LaunchedEffect(ambientMusicFile) {
+                    hasAmbientTrack = ambientMusicFile != null && ambientMusicFile?.exists() == true
                     try {
                         val file = ambientMusicFile
                         if (file != null && file.exists()) {

--- a/app/src/main/java/com/ilustris/sagai/MainActivity.kt
+++ b/app/src/main/java/com/ilustris/sagai/MainActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.ilustris.sagai.core.media.SagaPlaybackService
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -187,35 +188,38 @@ class MainActivity : ComponentActivity() {
                     }
                 }
 
-                // Pause/resume ambient when the app backgrounds (not when Nav 3 swaps screens).
+                // Pause ambient when activity is no longer visible; restart on onStart (foreground-safe).
                 val lifecycleOwner = LocalLifecycleOwner.current
+                val ambientMusicFile by sagaThemeManager.ambientMusicFile.collectAsState()
                 var hasAmbientTrack by remember { mutableStateOf(false) }
-                DisposableEffect(lifecycleOwner) {
+                DisposableEffect(lifecycleOwner, hasAmbientTrack, ambientMusicFile) {
                     val observer =
                         object : DefaultLifecycleObserver {
-                            override fun onPause(owner: LifecycleOwner) {
+                            override fun onStop(owner: LifecycleOwner) {
                                 if (!hasAmbientTrack) return
-                                startService(
-                                    Intent(
+                                SagaPlaybackService.startSafely(
+                                    applicationContext,
+                                    SagaPlaybackService.playbackIntent(
                                         applicationContext,
-                                        com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
-                                    ).apply {
-                                        action =
-                                            com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_PAUSE
-                                    },
+                                        SagaPlaybackService.ACTION_PAUSE,
+                                    ),
                                 )
                             }
 
-                            override fun onResume(owner: LifecycleOwner) {
+                            override fun onStart(owner: LifecycleOwner) {
                                 if (!hasAmbientTrack) return
-                                startService(
-                                    Intent(
+                                val path =
+                                    ambientMusicFile
+                                        ?.takeIf { it.exists() }
+                                        ?.absolutePath
+                                        ?: return
+                                SagaPlaybackService.startSafely(
+                                    applicationContext,
+                                    SagaPlaybackService.playbackIntent(
                                         applicationContext,
-                                        com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
-                                    ).apply {
-                                        action =
-                                            com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_RESUME
-                                    },
+                                        SagaPlaybackService.ACTION_START,
+                                        path,
+                                    ),
                                 )
                             }
                         }
@@ -224,40 +228,28 @@ class MainActivity : ComponentActivity() {
                 }
 
                 // Global Ambient Music Control
-                val ambientMusicFile by sagaThemeManager.ambientMusicFile.collectAsState()
                 LaunchedEffect(ambientMusicFile) {
                     hasAmbientTrack = ambientMusicFile != null && ambientMusicFile?.exists() == true
-                    try {
-                        val file = ambientMusicFile
-                        if (file != null && file.exists()) {
-                            Timber.d("Global music update: Playing ${file.absolutePath}")
-                            val musicIntent =
-                                Intent(
-                                    applicationContext,
-                                    com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
-                                ).apply {
-                                    action =
-                                        com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_START
-                                    putExtra(
-                                        com.ilustris.sagai.core.media.SagaPlaybackService.EXTRA_MUSIC_PATH,
-                                        file.absolutePath,
-                                    )
-                                }
-                            startService(musicIntent)
-                        } else {
-                            Timber.d("Global music update: Stopping playback")
-                            startService(
-                                Intent(
-                                    applicationContext,
-                                    com.ilustris.sagai.core.media.SagaPlaybackService::class.java,
-                                ).apply {
-                                    action =
-                                        com.ilustris.sagai.core.media.SagaPlaybackService.ACTION_STOP
-                                },
-                            )
-                        }
-                    } catch (e: Exception) {
-                        Timber.e(e, "Error updating global music playback")
+                    val file = ambientMusicFile
+                    if (file != null && file.exists()) {
+                        Timber.d("Global music update: Playing ${file.absolutePath}")
+                        SagaPlaybackService.startSafely(
+                            applicationContext,
+                            SagaPlaybackService.playbackIntent(
+                                applicationContext,
+                                SagaPlaybackService.ACTION_START,
+                                file.absolutePath,
+                            ),
+                        )
+                    } else {
+                        Timber.d("Global music update: Stopping playback")
+                        SagaPlaybackService.startSafely(
+                            applicationContext,
+                            SagaPlaybackService.playbackIntent(
+                                applicationContext,
+                                SagaPlaybackService.ACTION_STOP,
+                            ),
+                        )
                     }
                 }
 

--- a/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
@@ -60,10 +60,6 @@ class GemmaClient
         @PublishedApi
         internal val requestMutexes = java.util.concurrent.ConcurrentHashMap<String, Mutex>()
 
-        @PublishedApi
-        @Volatile
-        internal var retryDelay: Int? = null
-
         @Volatile
         var lastTokenCount: Int = 0
 
@@ -72,7 +68,23 @@ class GemmaClient
             const val INPUT_TOKEN_LIMIT = 15000
             const val REACTIVE_DELAY_THRESHOLD = 0.7f
             const val MAX_RETRIES = 2
-            const val RETRY_DELAY = 20
+
+            /** Fallback when the API omits RetryInfo on rate-limit responses. */
+            const val DEFAULT_RATE_LIMIT_RETRY_SECONDS = 3L
+
+            const val NETWORK_RETRY_SECONDS = 2L
+
+            fun retryDelaySeconds(
+                e: Exception,
+                isParsingError: Boolean,
+                extractedDelay: Long?,
+            ): Long =
+                when {
+                    isParsingError -> 0L
+                    extractedDelay != null -> extractedDelay
+                    e is java.io.IOException -> NETWORK_RETRY_SECONDS
+                    else -> DEFAULT_RATE_LIMIT_RETRY_SECONDS
+                }
         }
 
         enum class ModelRequirement {
@@ -150,20 +162,7 @@ class GemmaClient
                         throw GuardrailsException(safetyStatus)
                     }
                 }
-                if (lastTokenCount > (INPUT_TOKEN_LIMIT * REACTIVE_DELAY_THRESHOLD) && retryDelay == null) {
-                    if (logEnabled) Timber.w("Applying reactive delay due to high token count in last request.")
-                    retryDelay = 5
-                    delay((retryDelay ?: 5).seconds)
-                }
                 val model = modelName(requirement)
-                if (useCore.not()) {
-                    retryDelay?.let {
-                        if (logEnabled) Timber.e("generate: Trying delay $retryDelay seconds to avoid rate limit.")
-                        delay(it.seconds)
-                    }
-                } else {
-                    if (logEnabled) Timber.i("generate: Core calls don't require delay.")
-                }
 
                 val maxAttempts = MAX_RETRIES + 1
                 val startTime = System.currentTimeMillis()
@@ -282,7 +281,6 @@ class GemmaClient
                             }
 
                             lastTokenCount = response.usageMetadata?.promptTokenCount ?: 0
-                            retryDelay = null
                             if (lastTokenCount < (INPUT_TOKEN_LIMIT * REACTIVE_DELAY_THRESHOLD)) {
                                 lastTokenCount = 0
                             }
@@ -410,17 +408,9 @@ class GemmaClient
                             }
                         }
 
-                        val isNetworkError = e is java.io.IOException
                         if (currentAttempt < maxAttempts) {
                             val delayToApply =
-                                when {
-                                    isParsingError -> 0L
-
-                                    isNetworkError -> 2L
-
-                                    // Quick retry for DNS/Network hiccups
-                                    else -> (extractedDelay ?: RETRY_DELAY.toLong())
-                                }
+                                retryDelaySeconds(e, isParsingError, extractedDelay)
 
                             if (delayToApply > 0) {
                                 Timber
@@ -435,13 +425,6 @@ class GemmaClient
                                     ).w("Retrying immediately due to parsing error (${e.javaClass.simpleName})...")
                             }
                         } else {
-                            // Final failure
-                            if (!isParsingError) {
-                                retryDelay =
-                                    extractedDelay?.toInt() ?: retryDelay?.let {
-                                        if (it > 30) it / 2 else it + it
-                                    } ?: 2
-                            }
                             Timber.e("Final failure after $maxAttempts attempts.")
                             Timber.e("generate: Failed prompt")
                             Timber.w(prompt)
@@ -477,20 +460,7 @@ class GemmaClient
                             throw GuardrailsException(safetyStatus)
                         }
                     }
-                    if (lastTokenCount > (INPUT_TOKEN_LIMIT * REACTIVE_DELAY_THRESHOLD) && retryDelay == null) {
-                        Timber.w("Applying reactive delay due to high token count in last request.")
-                        retryDelay = 5
-                        delay((retryDelay ?: 5).seconds)
-                    }
                     val model = modelName(requirement)
-                    if (!useCore) {
-                        retryDelay?.let {
-                            if (logEnabled) Timber.e("generateStreaming: Trying delay $retryDelay seconds to avoid rate limit.")
-                            delay(it.seconds)
-                        }
-                    } else {
-                        if (logEnabled) Timber.i("generateStreaming: Core calls don't require delay.")
-                    }
 
                     val maxAttempts = MAX_RETRIES + 1
                     val startTime = System.currentTimeMillis()
@@ -674,7 +644,6 @@ class GemmaClient
 
                             Timber.d("generateStreaming: final state on streaming:\n${aiGeneration.toJsonFormat()}")
                             emit(StreamingState.Success(aiGeneration.data))
-                            retryDelay = null
                             return@flow
                         } catch (e: Exception) {
                             if (e.isFlowCancellation()) {
@@ -715,17 +684,9 @@ class GemmaClient
                                 }
                             }
 
-                            val isNetworkError = e is java.io.IOException
                             if (currentAttempt < maxAttempts) {
                                 val delayToApply =
-                                    when {
-                                        isParsingError -> 0L
-
-                                        isNetworkError -> 2L
-
-                                        // Quick retry for DNS/Network hiccups
-                                        else -> (extractedDelay ?: RETRY_DELAY.toLong())
-                                    }
+                                    retryDelaySeconds(e, isParsingError, extractedDelay)
                                 if (delayToApply > 0) delay(delayToApply.seconds)
                             } else {
                                 if (logEnabled && BuildConfig.DEBUG) {
@@ -743,10 +704,6 @@ class GemmaClient
                                             safetyStatus = safetyStatus,
                                         ),
                                     )
-                                }
-                                if (!isParsingError) {
-                                    retryDelay = extractedDelay?.toInt()
-                                        ?: retryDelay?.let { if (it > 30) it / 2 else it + it } ?: 2
                                 }
                                 emit(StreamingState.Error(e.message ?: "Unknown error", e))
                                 return@flow

--- a/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/GemmaClient.kt
@@ -28,6 +28,8 @@ import com.ilustris.sagai.core.utils.sanitizeAndExtractJsonString
 import com.ilustris.sagai.core.utils.toJsonFormat
 import com.ilustris.sagai.core.utils.toJsonFormatExcludingFields
 import com.ilustris.sagai.core.utils.toJsonMap
+import com.ilustris.sagai.core.data.isFlowCancellation
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -675,6 +677,9 @@ class GemmaClient
                             retryDelay = null
                             return@flow
                         } catch (e: Exception) {
+                            if (e.isFlowCancellation()) {
+                                throw e
+                            }
                             if (logEnabled) {
                                 Timber
                                     .tag(
@@ -749,6 +754,9 @@ class GemmaClient
                         }
                     }
                 } catch (e: Exception) {
+                    if (e.isFlowCancellation()) {
+                        throw e
+                    }
                     emit(StreamingState.Error(e.message ?: "Unknown error", e))
                 }
             }.flowOn(Dispatchers.IO)

--- a/app/src/main/java/com/ilustris/sagai/core/ai/StreamingState.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/StreamingState.kt
@@ -1,5 +1,7 @@
 package com.ilustris.sagai.core.ai
 
+import com.ilustris.sagai.core.data.isFlowCancellation
+
 sealed class StreamingState<out T> {
     data class Reasoning(
         val chunk: String,
@@ -12,5 +14,12 @@ sealed class StreamingState<out T> {
     data class Error(
         val message: String,
         val throwable: Throwable? = null,
-    ) : StreamingState<Nothing>()
+    ) : StreamingState<Nothing>() {
+        fun isFlowCancellation(): Boolean =
+            throwable?.isFlowCancellation() == true || message.isFlowCancellation()
+    }
 }
+
+private fun String.isFlowCancellation(): Boolean =
+    contains("child flow", ignoreCase = true) ||
+        contains("scoped flow was cancelled", ignoreCase = true)

--- a/app/src/main/java/com/ilustris/sagai/core/ai/services/ReasoningSynthesizerService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/ai/services/ReasoningSynthesizerService.kt
@@ -6,6 +6,7 @@ import com.ilustris.sagai.core.ai.StreamingState
 import com.ilustris.sagai.core.ai.model.ReasoningFallbacks
 import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.features.onboarding.data.OnboardingPrompts
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.ProducerScope
@@ -46,14 +47,18 @@ class ReasoningSynthesizerService
                                 if (synthesisJob?.isActive != true && lastReasoning.length > 50) {
                                     synthesisJob =
                                         launch {
-                                            synthesizeNow(
-                                                lastReasoning,
-                                                context,
-                                                conversationStyle,
-                                                getLanguage(true),
-                                                this@channelFlow,
-                                                genre,
-                                            )
+                                            try {
+                                                synthesizeNow(
+                                                    lastReasoning,
+                                                    context,
+                                                    conversationStyle,
+                                                    getLanguage(true),
+                                                    this@channelFlow,
+                                                    genre,
+                                                )
+                                            } catch (_: CancellationException) {
+                                                // Replaced by a newer reasoning chunk or flow completion.
+                                            }
                                         }
                                 }
                             } else {
@@ -63,14 +68,18 @@ class ReasoningSynthesizerService
 
                         is StreamingState.Success -> {
                             if (showReasoning && lastReasoning.isNotBlank()) {
-                                synthesizeNow(
-                                    lastReasoning,
-                                    context,
-                                    conversationStyle,
-                                    getLanguage(true),
-                                    this,
-                                    genre,
-                                )
+                                try {
+                                    synthesizeNow(
+                                        lastReasoning,
+                                        context,
+                                        conversationStyle,
+                                        getLanguage(true),
+                                        this,
+                                        genre,
+                                    )
+                                } catch (_: CancellationException) {
+                                    // Flow completed while synthesis was running.
+                                }
                             }
                             synthesisJob?.cancel()
                             send(state)

--- a/app/src/main/java/com/ilustris/sagai/core/data/RequestResult.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/data/RequestResult.kt
@@ -1,6 +1,7 @@
 package com.ilustris.sagai.core.data
 
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import kotlinx.coroutines.CancellationException
 
 // Changed: Only one generic type for Success
 sealed class RequestResult<out R> {
@@ -67,6 +68,13 @@ sealed class RequestResult<out R> {
         }
 }
 
+/** Flow/coroutine cancellation — not a user-visible failure. */
+fun Throwable.isFlowCancellation(): Boolean =
+    this is CancellationException ||
+        this::class.simpleName == "ChildCancelledException" ||
+        message?.contains("child flow", ignoreCase = true) == true ||
+        message?.contains("scoped flow was cancelled", ignoreCase = true) == true
+
 // asSuccess remains largely the same
 fun <R> R.asSuccess(): RequestResult.Success<R> = RequestResult.Success(this)
 
@@ -86,5 +94,8 @@ suspend fun <R> executeRequest(
     try {
         block().asSuccess()
     } catch (e: Exception) {
+        if (e.isFlowCancellation()) {
+            throw e
+        }
         e.asError(reportCrash)
     }

--- a/app/src/main/java/com/ilustris/sagai/core/lifecycle/AppLifecycleManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/lifecycle/AppLifecycleManagerImpl.kt
@@ -28,8 +28,4 @@ class AppLifecycleManagerImpl
         override fun onStop(owner: LifecycleOwner) {
             _isAppInForeground.value = false
         }
-
-        override fun onPause(owner: LifecycleOwner) {
-            _isAppInForeground.value = false
-        }
     }

--- a/app/src/main/java/com/ilustris/sagai/core/media/SagaPlaybackService.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/media/SagaPlaybackService.kt
@@ -4,6 +4,8 @@ import android.app.Service
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.ProcessLifecycleOwner
 import android.content.IntentFilter
 import android.media.AudioManager
 import android.os.Binder
@@ -165,5 +167,43 @@ class SagaPlaybackService : Service() {
         const val ACTION_PAUSE = "com.ilustris.sagai.ACTION_PAUSE_MUSIC"
         const val ACTION_RESUME = "com.ilustris.sagai.ACTION_RESUME_MUSIC"
         const val EXTRA_MUSIC_PATH = "EXTRA_MUSIC_PATH"
+
+        fun playbackIntent(
+            context: Context,
+            action: String,
+            musicPath: String? = null,
+        ): Intent =
+            Intent(context, SagaPlaybackService::class.java).apply {
+                this.action = action
+                musicPath?.let { putExtra(EXTRA_MUSIC_PATH, it) }
+            }
+
+        /**
+         * Starts or signals [SagaPlaybackService] only while the app process is in the foreground.
+         * Avoids [android.app.BackgroundServiceStartNotAllowedException] when the activity resumes
+         * after the process was backgrounded for a long time (e.g. screen lock).
+         */
+        fun startSafely(
+            context: Context,
+            intent: Intent,
+        ): Boolean {
+            val processStarted =
+                ProcessLifecycleOwner.get().lifecycle.currentState
+                    .isAtLeast(Lifecycle.State.STARTED)
+            if (!processStarted) {
+                Timber.i("SagaPlaybackService: skipped start — app not in foreground (action=${intent.action})")
+                return false
+            }
+            return try {
+                context.startService(intent)
+                true
+            } catch (e: IllegalStateException) {
+                Timber.w(e, "SagaPlaybackService: start blocked (action=${intent.action})")
+                false
+            } catch (e: Exception) {
+                Timber.e(e, "SagaPlaybackService: start failed (action=${intent.action})")
+                false
+            }
+        }
     }
 }

--- a/app/src/main/java/com/ilustris/sagai/core/navigation/SagaNavigationTracker.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/navigation/SagaNavigationTracker.kt
@@ -1,0 +1,27 @@
+package com.ilustris.sagai.core.navigation
+
+import com.ilustris.sagai.ui.navigation.ChatKey
+import androidx.navigation3.runtime.NavKey
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/** Tracks the visible Nav 3 destination for in-app vs system notification routing. */
+@Singleton
+class SagaNavigationTracker
+    @Inject
+    constructor() {
+        private val _currentKey = MutableStateFlow<NavKey?>(null)
+        val currentKey: StateFlow<NavKey?> = _currentKey.asStateFlow()
+
+        fun update(key: NavKey) {
+            _currentKey.value = key
+        }
+
+        fun isOnChatForSaga(sagaId: Int): Boolean {
+            val key = _currentKey.value
+            return key is ChatKey && key.sagaId == sagaId.toString()
+        }
+    }

--- a/app/src/main/java/com/ilustris/sagai/core/notifications/SagaInAppNotification.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/notifications/SagaInAppNotification.kt
@@ -1,0 +1,14 @@
+package com.ilustris.sagai.core.notifications
+
+import android.graphics.Bitmap
+import com.ilustris.sagai.features.newsaga.data.model.Genre
+
+/** Heads-up style payload shown inside the app (WhatsApp-like), not a system notification. */
+data class SagaInAppNotification(
+    val sagaId: Int,
+    val sagaTitle: String,
+    val genre: Genre,
+    val message: String,
+    val deepLink: String,
+    val icon: Bitmap? = null,
+)

--- a/app/src/main/java/com/ilustris/sagai/core/notifications/SagaNotificationRouter.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/notifications/SagaNotificationRouter.kt
@@ -1,0 +1,120 @@
+package com.ilustris.sagai.core.notifications
+
+import com.ilustris.sagai.core.lifecycle.AppLifecycleManager
+import com.ilustris.sagai.core.navigation.SagaNavigationTracker
+import com.ilustris.sagai.features.home.data.model.SagaMetadata
+import com.ilustris.sagai.features.saga.chat.data.manager.ChatNotificationManager
+import com.ilustris.sagai.features.saga.chat.data.manager.SagaContentManager
+import com.ilustris.sagai.features.settings.domain.SettingsUseCase
+import com.ilustris.sagai.ui.components.SagaNotificationEvent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Routes saga events to in-app heads-up (foreground, outside chat) or system notifications (background).
+ */
+@Singleton
+class SagaNotificationRouter
+    @Inject
+    constructor(
+        private val sagaContentManager: SagaContentManager,
+        private val chatNotificationManager: ChatNotificationManager,
+        private val appLifecycleManager: AppLifecycleManager,
+        private val navigationTracker: SagaNavigationTracker,
+        private val settingsUseCase: SettingsUseCase,
+    ) {
+        private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate)
+
+        private val _inAppNotification = MutableStateFlow<SagaInAppNotification?>(null)
+        val inAppNotification: StateFlow<SagaInAppNotification?> = _inAppNotification.asStateFlow()
+
+        private var collectJob: Job? = null
+        private var dismissJob: Job? = null
+        private var started = false
+
+        fun start() {
+            if (started) return
+            started = true
+            collectJob =
+                scope.launch {
+                    sagaContentManager.notificationUpdate.collect { event ->
+                        val payload = event ?: return@collect
+                        if (!settingsUseCase.getNotificationsEnabled().first()) return@collect
+                        deliver(payload)
+                    }
+                }
+        }
+
+        fun dismissInApp() {
+            dismissJob?.cancel()
+            _inAppNotification.value = null
+        }
+
+        private fun deliver(event: SagaNotificationEvent) {
+            if (!shouldNotify(event.sagaId)) {
+                Timber.d("SagaNotificationRouter: suppressed (user on chat for saga ${event.sagaId})")
+                return
+            }
+
+            val deepLink = chatDeepLink(event.sagaId)
+            val inForeground = appLifecycleManager.isAppInForeground.value
+
+            if (inForeground) {
+                showInApp(
+                    SagaInAppNotification(
+                        sagaId = event.sagaId,
+                        sagaTitle = event.sagaTitle,
+                        genre = event.genre,
+                        message = event.message,
+                        deepLink = deepLink,
+                        icon = event.icon ?: event.largeIcon,
+                    ),
+                )
+            } else {
+                dismissInApp()
+                val sagaMeta =
+                    SagaMetadata(
+                        data =
+                            com.ilustris.sagai.features.home.data.model.Saga(
+                                id = event.sagaId,
+                                title = event.sagaTitle,
+                                genre = event.genre,
+                            ),
+                    )
+                chatNotificationManager.deliverSystemNotification(sagaMeta, event)
+            }
+        }
+
+        private fun shouldNotify(sagaId: Int): Boolean {
+            if (!appLifecycleManager.isAppInForeground.value) return true
+            return !navigationTracker.isOnChatForSaga(sagaId)
+        }
+
+        private fun showInApp(notification: SagaInAppNotification) {
+            _inAppNotification.value = notification
+            dismissJob?.cancel()
+            dismissJob =
+                scope.launch {
+                    delay(6.seconds)
+                    if (_inAppNotification.value?.sagaId == notification.sagaId &&
+                        _inAppNotification.value?.message == notification.message
+                    ) {
+                        _inAppNotification.value = null
+                    }
+                }
+        }
+
+        private fun chatDeepLink(sagaId: Int): String = "saga://chat/$sagaId/false"
+    }

--- a/app/src/main/java/com/ilustris/sagai/core/segmentation/ImageSegmentationHelper.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/segmentation/ImageSegmentationHelper.kt
@@ -51,6 +51,10 @@ class ImageSegmentationHelper(
             bitmap to segmenter.process(image).await()?.foregroundBitmap!!
         }
 
+    @Deprecated(
+        message = "Smart zoom is deprecated; UI uses plain image crop for character avatars.",
+        level = DeprecationLevel.WARNING,
+    )
     suspend fun calculateSmartZoom(url: String): RequestResult<SmartZoom?> =
         executeRequest {
             if (url.isBlank()) {

--- a/app/src/main/java/com/ilustris/sagai/core/theme/SagaImmersiveSession.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/theme/SagaImmersiveSession.kt
@@ -35,4 +35,7 @@ class SagaImmersiveSession
         }
 
         fun isSagaActive(sagaId: Int): Boolean = stack.lastOrNull()?.second == sagaId
+
+        /** True when [owner] is the topmost visible saga screen (not buried under Chat, etc.). */
+        fun isOwnerOnTop(owner: String): Boolean = stack.lastOrNull()?.first == owner
     }

--- a/app/src/main/java/com/ilustris/sagai/core/theme/SagaImmersiveSession.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/theme/SagaImmersiveSession.kt
@@ -1,0 +1,38 @@
+package com.ilustris.sagai.core.theme
+
+import timber.log.Timber
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tracks which saga screen is currently visible in the Nav 3 stack.
+ * Prevents preserved/backstack screens (e.g. Chat under Home) from calling [SagaThemeManager]
+ * while the user is on Home or another saga.
+ */
+@Singleton
+class SagaImmersiveSession
+    @Inject
+    constructor() {
+        private val stack = ArrayDeque<Pair<String, Int>>()
+
+        fun push(
+            owner: String,
+            sagaId: Int,
+        ) {
+            stack.addLast(owner to sagaId)
+            Timber.d("SagaImmersiveSession: push $owner saga=$sagaId (depth=${stack.size})")
+        }
+
+        fun pop(owner: String) {
+            val index = stack.indexOfLast { it.first == owner }
+            if (index < 0) return
+            while (stack.size > index) {
+                stack.removeLast()
+            }
+            Timber.d(
+                "SagaImmersiveSession: pop $owner (depth=${stack.size}, active=${stack.lastOrNull()?.second})",
+            )
+        }
+
+        fun isSagaActive(sagaId: Int): Boolean = stack.lastOrNull()?.second == sagaId
+    }

--- a/app/src/main/java/com/ilustris/sagai/core/theme/SagaThemeManager.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/theme/SagaThemeManager.kt
@@ -9,6 +9,8 @@ import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.features.newsaga.data.model.Genre
 import com.ilustris.sagai.features.newsaga.data.model.vibrationPattern
 import com.ilustris.sagai.ui.components.SagaSnackBarMessage
+import android.os.SystemClock
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -63,6 +65,14 @@ class SagaThemeManager
         /** Genre requested while still on a neutral screen (Home, etc.) — applied when leaving neutral. */
         private var pendingGenre: Genre? = null
 
+        private var themeFetchJob: Job? = null
+
+        private var lastEntryVfxGenre: Genre? = null
+
+        private var lastEntryVfxAtMs = 0L
+
+        private val entryVfxMinIntervalMs = 2_000L
+
         /**
          * Updates the neutrality state of the manager.
          * When neutral, any attempt to set a genre is ignored, and the theme is reset.
@@ -101,26 +111,44 @@ class SagaThemeManager
 
             _currentGenre.value = genre
             if (genre != null) {
-                managerScope.launch {
-                    fetchConfigs(genre, playEntryVfx)
-                }
+                themeFetchJob?.cancel()
+                themeFetchJob =
+                    managerScope.launch {
+                        try {
+                            val playEntry = playEntryVfx && shouldPlayEntryVfx(genre)
+                            fetchConfigs(genre, playEntry)
+                        } catch (e: CancellationException) {
+                            throw e
+                        } catch (e: Exception) {
+                            Timber.e(e, "SagaThemeManager: Error fetching media configs for $genre")
+                        }
+                    }
             } else {
+                themeFetchJob?.cancel()
+                themeFetchJob = null
                 resetTheme()
             }
+        }
+
+        private fun shouldPlayEntryVfx(genre: Genre): Boolean {
+            val now = SystemClock.elapsedRealtime()
+            if (lastEntryVfxGenre == genre && now - lastEntryVfxAtMs < entryVfxMinIntervalMs) {
+                Timber.d("SagaThemeManager: entry VFX skipped (debounced for $genre)")
+                return false
+            }
+            lastEntryVfxGenre = genre
+            lastEntryVfxAtMs = now
+            return true
         }
 
         private suspend fun fetchConfigs(
             genre: Genre,
             playEntryVfx: Boolean = false,
         ) {
-            try {
-                getAmbienceMusic(genre)
-                getReplySfx(genre)
-                if (playEntryVfx) {
-                    playVfxInternal()
-                }
-            } catch (e: Exception) {
-                Timber.e(e, "SagaThemeManager: Error fetching media configs for $genre")
+            getAmbienceMusic(genre)
+            getReplySfx(genre)
+            if (playEntryVfx) {
+                playVfxInternal()
             }
         }
 
@@ -175,6 +203,10 @@ class SagaThemeManager
 
         /** Clear the active genre, reverting to the default brand identity. */
         fun resetTheme() {
+            themeFetchJob?.cancel()
+            themeFetchJob = null
+            lastEntryVfxGenre = null
+            lastEntryVfxAtMs = 0L
             _currentGenre.value = null
             _ambientMusicFile.value = null
         }

--- a/app/src/main/java/com/ilustris/sagai/core/utils/DataExtensions.kt
+++ b/app/src/main/java/com/ilustris/sagai/core/utils/DataExtensions.kt
@@ -818,6 +818,28 @@ fun Long.formatFileSize(): String {
     }
 }
 
+/** Default cap for long descriptive strings (backstory, summaries, etc.). */
+private const val AI_STRING_TRUNCATE_DEFAULT = 500
+
+/** Chat message bodies — must not clip below UI `chat_input_limit` (default 2000). */
+private const val AI_MESSAGE_TEXT_MAX = 8_192
+
+private fun truncateForAi(
+    fieldName: String,
+    value: String,
+): String {
+    val limit =
+        when (fieldName) {
+            "text" -> AI_MESSAGE_TEXT_MAX
+            else -> AI_STRING_TRUNCATE_DEFAULT
+        }
+    return if (value.length > limit) {
+        "${value.take(limit - 3)}..."
+    } else {
+        value
+    }
+}
+
 fun Any?.toAINormalize(fieldsToExclude: List<String> = emptyList()): String {
     if (this == null) return ""
     if (this is String || this is Number || this is Boolean || this is Enum<*>) {
@@ -855,13 +877,7 @@ fun Any?.toAINormalize(fieldsToExclude: List<String> = emptyList()): String {
                         }
                     }
 
-                    is String -> {
-                        if (value.length > 500) {
-                            "${value.take(497)}..."
-                        } else {
-                            value
-                        }
-                    }
+                    is String -> truncateForAi(field.name, value)
 
                     is Enum<*> -> {
                         value.toString()

--- a/app/src/main/java/com/ilustris/sagai/features/act/data/usecase/ActUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/act/data/usecase/ActUseCaseImpl.kt
@@ -362,6 +362,9 @@ class ActUseCaseImpl
                             }
                         }
                 } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) {
+                        throw e
+                    }
                     emit(StreamingState.Error(e.message ?: "Act synthesis failed", e))
                 }
             }

--- a/app/src/main/java/com/ilustris/sagai/features/act/ui/components/BookShelf.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/act/ui/components/BookShelf.kt
@@ -46,6 +46,7 @@ import com.ilustris.sagai.features.newsaga.data.model.shimmerColors
 import com.ilustris.sagai.features.newsaga.data.usecase.SagaBook
 import com.ilustris.sagai.ui.animations.chromaticAberration
 import com.ilustris.sagai.ui.animations.divineAura
+import com.ilustris.sagai.ui.components.BookGenerationReasoning
 import com.ilustris.sagai.ui.components.CosmicBook
 import com.ilustris.sagai.ui.theme.grayScale
 import com.ilustris.sagai.ui.theme.levitate
@@ -156,40 +157,6 @@ private fun SharedTransitionScope.GeneratingBookFocus(
             visualConfig = visualConfig,
             modifier = Modifier.padding(top = 24.dp),
         )
-    }
-}
-
-@Composable
-private fun BookGenerationReasoning(
-    reasoning: String?,
-    genre: com.ilustris.sagai.features.newsaga.data.model.Genre,
-    visualConfig: GenreVisualConfig,
-    modifier: Modifier = Modifier,
-) {
-    AnimatedContent(
-        targetState = reasoning,
-        label = "BookGenerationReasoning",
-        transitionSpec = {
-            fadeIn(tween(300)) togetherWith fadeOut(tween(200))
-        },
-        modifier = modifier.fillMaxWidth(),
-    ) { text ->
-        if (text != null) {
-            Text(
-                text = text,
-                style =
-                    MaterialTheme.typography.bodyMedium.copy(
-                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                        lineHeight = 22.sp,
-                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
-                        textAlign = TextAlign.Center,
-                    ),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .reactiveShimmer(true, genre.shimmerColors(visualConfig)),
-            )
-        }
     }
 }
 

--- a/app/src/main/java/com/ilustris/sagai/features/act/ui/components/BookShelf.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/act/ui/components/BookShelf.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -34,7 +33,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -48,7 +46,6 @@ import com.ilustris.sagai.features.newsaga.data.model.shimmerColors
 import com.ilustris.sagai.features.newsaga.data.usecase.SagaBook
 import com.ilustris.sagai.ui.animations.chromaticAberration
 import com.ilustris.sagai.ui.animations.divineAura
-import com.ilustris.sagai.ui.animations.genreVfx
 import com.ilustris.sagai.ui.components.CosmicBook
 import com.ilustris.sagai.ui.theme.grayScale
 import com.ilustris.sagai.ui.theme.levitate
@@ -169,44 +166,29 @@ private fun BookGenerationReasoning(
     visualConfig: GenreVisualConfig,
     modifier: Modifier = Modifier,
 ) {
-    Column(
+    AnimatedContent(
+        targetState = reasoning,
+        label = "BookGenerationReasoning",
+        transitionSpec = {
+            fadeIn(tween(300)) togetherWith fadeOut(tween(200))
+        },
         modifier = modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Icon(
-            painter = painterResource(genre.icon),
-            contentDescription = null,
-            tint = genre.resolveColor(visualConfig),
-            modifier =
-                Modifier
-                    .padding(bottom = 4.dp)
-                    .genreVfx(genre),
-        )
-
-        AnimatedContent(
-            targetState = reasoning,
-            label = "BookGenerationReasoning",
-            transitionSpec = {
-                fadeIn(tween(300)) togetherWith fadeOut(tween(200))
-            },
-        ) { text ->
-            if (text != null) {
-                Text(
-                    text = text,
-                    style =
-                        MaterialTheme.typography.bodyMedium.copy(
-                            fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                            lineHeight = 22.sp,
-                            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
-                            textAlign = TextAlign.Center,
-                        ),
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .reactiveShimmer(true, genre.shimmerColors(visualConfig)),
-                )
-            }
+    ) { text ->
+        if (text != null) {
+            Text(
+                text = text,
+                style =
+                    MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                        lineHeight = 22.sp,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+                        textAlign = TextAlign.Center,
+                    ),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .reactiveShimmer(true, genre.shimmerColors(visualConfig)),
+            )
         }
     }
 }

--- a/app/src/main/java/com/ilustris/sagai/features/chapter/data/usecase/ChapterUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/chapter/data/usecase/ChapterUseCaseImpl.kt
@@ -536,6 +536,9 @@ class ChapterUseCaseImpl
                             }
                         }
                 } catch (e: Exception) {
+                    if (e is kotlinx.coroutines.CancellationException) {
+                        throw e
+                    }
                     emit(StreamingState.Error(e.message ?: "Chapter synthesis failed", e))
                 }
             }

--- a/app/src/main/java/com/ilustris/sagai/features/characters/data/model/Character.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/data/model/Character.kt
@@ -55,6 +55,10 @@ data class Character(
     @ColumnInfo(index = true)
     val firstSceneId: Int? = null,
     val emojified: Boolean = false,
+    @Deprecated(
+        message = "Smart zoom is no longer applied in UI. Kept for DB compatibility only.",
+        level = DeprecationLevel.WARNING,
+    )
     @Embedded(prefix = "zoom_")
     val smartZoom: SmartZoom? = null,
     @ColumnInfo(defaultValue = "")
@@ -112,6 +116,10 @@ data class FacialFeatures(
     val jawline: String = "",
 )
 
+@Deprecated(
+    message = "Portrait segmentation zoom is deprecated; avatars use ContentScale.Crop only.",
+    level = DeprecationLevel.WARNING,
+)
 data class SmartZoom(
     val scale: Float = 1f,
     val translationX: Float = 0f,

--- a/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCase.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCase.kt
@@ -52,6 +52,10 @@ interface CharacterUseCase {
         candidateName: String? = null,
     ): Flow<StreamingState<GeneratedContent<Character>>>
 
+    @Deprecated(
+        message = "Smart zoom is deprecated and no longer scheduled from chat or avatars.",
+        level = DeprecationLevel.WARNING,
+    )
     suspend fun createSmartZoom(character: Character): RequestResult<Unit>
 
     suspend fun generateCharactersUpdate(

--- a/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCaseImpl.kt
@@ -359,6 +359,7 @@ class CharacterUseCaseImpl
                         .synthesizeReasoning(
                             request,
                             "Bringing character to the story...",
+                            conversationStyle = genreConfigService.conversationBlueprint(sagaContent.data.genre),
                         ).collect { state ->
                             if (state is StreamingState.Success) {
                                 val newCharacter = state.data.data

--- a/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/data/usecase/CharacterUseCaseImpl.kt
@@ -214,6 +214,7 @@ class CharacterUseCaseImpl
                 }
             }
 
+        @Deprecated("Smart zoom is deprecated and no longer scheduled from chat or avatars.")
         override suspend fun createSmartZoom(character: Character): RequestResult<Unit> =
             executeRequest {
                 Timber.i("createSmartZoom: creating zoom for ${character.name}")

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterAvatar.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterAvatar.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -30,9 +31,9 @@ import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.ilustris.sagai.features.characters.data.model.Character
 import com.ilustris.sagai.features.newsaga.data.model.Genre
-import com.ilustris.sagai.ui.theme.darker
 import com.ilustris.sagai.ui.theme.darkerPalette
 import com.ilustris.sagai.ui.theme.filters.effectForGenre
+import com.ilustris.sagai.ui.theme.gradientFade
 import com.ilustris.sagai.ui.theme.hexToColor
 import com.ilustris.sagai.ui.theme.reactiveShimmer
 import com.ilustris.sagai.ui.theme.solidGradient
@@ -77,11 +78,10 @@ fun CharacterAvatar(
                 borderSize,
                 borderBrush,
                 CircleShape,
-            )
-            .clip(CircleShape)
+            ).clip(CircleShape)
             .padding(innerPadding)
             .background(
-                characterColor.darker(.3f),
+                Brush.verticalGradient(characterColor.darkerPalette(factor = .35f)),
                 CircleShape,
             ),
     ) {
@@ -94,12 +94,13 @@ fun CharacterAvatar(
                     textStyle.copy(
                         fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
                         brush =
-                            Brush.verticalGradient(
-                                characterColor.darkerPalette(factor = .2f),
-                            ),
+                            MaterialTheme.colorScheme.onBackground.gradientFade(),
                     ),
                 fontWeight = FontWeight.Black,
-                modifier = Modifier.align(Alignment.Center),
+                modifier =
+                    Modifier
+                        .align(Alignment.Center)
+                        .alpha(.4f),
             )
         }
 
@@ -113,8 +114,7 @@ fun CharacterAvatar(
                             memoryCacheKey("${character.id}:$imagePath")
                             diskCacheKey("${character.id}:$imagePath")
                         }
-                    }
-                    .crossfade(true)
+                    }.crossfade(true)
                     .build(),
             contentDescription = character.name,
             contentScale = ContentScale.Crop,
@@ -126,6 +126,7 @@ fun CharacterAvatar(
                         -> true
 
                         is AsyncImagePainter.State.Success -> false
+
                         else -> imageLoadFailed
                     }
             },

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterAvatar.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterAvatar.kt
@@ -1,22 +1,23 @@
 package com.ilustris.sagai.features.characters.ui
-import androidx.compose.animation.core.animateFloatAsState
+
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.TransformOrigin
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
@@ -24,6 +25,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
+import coil3.compose.AsyncImagePainter
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import com.ilustris.sagai.features.characters.data.model.Character
@@ -35,6 +37,9 @@ import com.ilustris.sagai.ui.theme.hexToColor
 import com.ilustris.sagai.ui.theme.reactiveShimmer
 import com.ilustris.sagai.ui.theme.solidGradient
 import com.ilustris.sagai.ui.theme.themeShimmer
+
+/** Avatars are small; genre shaders / heavy blur destroy legibility on tiny targets. */
+private val GenreEffectMaxSize = 120.dp
 
 @Composable
 fun CharacterAvatar(
@@ -62,78 +67,85 @@ fun CharacterAvatar(
             ),
         )
 
-    val smartZoom = character.smartZoom
+    val imagePath = character.image.trim()
+    var imageLoadFailed by remember(character.id, imagePath) { mutableStateOf(imagePath.isBlank()) }
 
-    val animatedScale by animateFloatAsState(
-        targetValue = smartZoom?.scale ?: 1f,
-        label = "SmartZoomScale",
-    )
-    val animatedTranslationX by animateFloatAsState(
-        targetValue = smartZoom?.translationX ?: 0f,
-        label = "SmartZoomTranslationX",
-    )
-    val animatedTranslationY by animateFloatAsState(
-        targetValue = smartZoom?.translationY ?: 0f,
-        label = "SmartZoomTranslationY",
-    )
-
-    Box(
+    BoxWithConstraints(
         modifier
             .reactiveShimmer(isLoading, themeShimmer())
             .border(
                 borderSize,
                 borderBrush,
                 CircleShape,
-            ).clip(CircleShape)
+            )
+            .clip(CircleShape)
             .padding(innerPadding)
             .background(
                 characterColor.darker(.3f),
                 CircleShape,
             ),
     ) {
-        androidx.compose.material3.Text(
-            character.name.first().uppercase(),
-            style =
-                textStyle.copy(
-                    fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
-                    brush =
-                        Brush.verticalGradient(
-                            characterColor.darkerPalette(factor = .2f),
-                        ),
-                ),
-            fontWeight = FontWeight.Black,
-            modifier = Modifier.align(Alignment.Center),
-        )
+        val skipGenreEffect = maxWidth < GenreEffectMaxSize && maxHeight < GenreEffectMaxSize
+
+        if (imageLoadFailed) {
+            Text(
+                character.name.first().uppercase(),
+                style =
+                    textStyle.copy(
+                        fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
+                        brush =
+                            Brush.verticalGradient(
+                                characterColor.darkerPalette(factor = .2f),
+                            ),
+                    ),
+                fontWeight = FontWeight.Black,
+                modifier = Modifier.align(Alignment.Center),
+            )
+        }
 
         AsyncImage(
             model =
                 ImageRequest
                     .Builder(LocalContext.current)
-                    .data(character.image)
+                    .data(imagePath.takeIf { it.isNotBlank() })
+                    .apply {
+                        if (imagePath.isNotBlank()) {
+                            memoryCacheKey("${character.id}:$imagePath")
+                            diskCacheKey("${character.id}:$imagePath")
+                        }
+                    }
                     .crossfade(true)
                     .build(),
             contentDescription = character.name,
             contentScale = ContentScale.Crop,
+            onState = { state ->
+                imageLoadFailed =
+                    when (state) {
+                        is AsyncImagePainter.State.Error,
+                        is AsyncImagePainter.State.Empty,
+                        -> true
+
+                        is AsyncImagePainter.State.Success -> false
+                        else -> imageLoadFailed
+                    }
+            },
             modifier =
                 Modifier
+                    .fillMaxSize()
                     .clip(CircleShape)
-                    .background(
-                        characterColor.copy(alpha = 0.4f),
-                        CircleShape,
-                    ).fillMaxSize()
-                    .effectForGenre(
-                        genre,
-                        useFallBack = useFallback,
-                        focusRadius = softFocusRadius,
-                        customGrain = grainRadius,
-                        pixelSize = pixelation,
-                    ).graphicsLayer {
-                        scaleX = animatedScale
-                        scaleY = animatedScale
-                        translationX = animatedTranslationX * size.width
-                        translationY = animatedTranslationY * size.height
-                        transformOrigin = TransformOrigin.Center
-                    }.clipToBounds(),
+                    .then(
+                        if (!skipGenreEffect) {
+                            Modifier.effectForGenre(
+                                genre,
+                                useFallBack = useFallback,
+                                focusRadius = softFocusRadius,
+                                customGrain = grainRadius,
+                                pixelSize = pixelation,
+                            )
+                        } else {
+                            Modifier
+                        },
+                    ),
         )
     }
 }

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -255,8 +256,7 @@ private fun CharacterDetailsLoaded(
                                             .sharedBounds(
                                                 rememberSharedContentState(key = "character_${character.id}_icon"),
                                                 animatedVisibilityScope,
-                                            )
-                                            .fillParentMaxHeight(.6f)
+                                            ).fillParentMaxHeight(.6f)
                                             .fillMaxSize()
                                             .clickable(enabled = characterData.emojified || characterData.image.isEmpty()) {
                                                 viewModel.regenerate(
@@ -270,17 +270,21 @@ private fun CharacterDetailsLoaded(
                                             .fillMaxSize()
                                             .effectForGenre(
                                                 genre,
-                                            )
-                                            .graphicsLayer(
+                                            ).graphicsLayer(
                                                 translationY = 120f,
                                             ),
                                 ) {
-                                    Box(
-                                        Modifier
-                                            .align(Alignment.TopCenter)
-                                            .fillMaxSize()
-                                            .background(fadeGradientTop(adaptiveColor)),
-                                    ) {
+                                    Box(Modifier.fillMaxSize()) {
+                                        Box(
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .fillMaxHeight(.2f)
+                                                .background(
+                                                    fadeGradientTop(
+                                                        adaptiveColor,
+                                                    ),
+                                                ),
+                                        )
                                         genre.stylisedText(
                                             text = "${characterData.name} ${(characterData.lastName ?: emptyString())}".trim(),
                                             modifier =
@@ -292,8 +296,7 @@ private fun CharacterDetailsLoaded(
                                                         Brush.verticalGradient(
                                                             characterColor.darkerPalette(),
                                                         ),
-                                                    )
-                                                    .reactiveShimmer(
+                                                    ).reactiveShimmer(
                                                         true,
                                                         characterColor.shimmerize(),
                                                     ),

--- a/app/src/main/java/com/ilustris/sagai/features/home/ui/HomeView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/home/ui/HomeView.kt
@@ -125,6 +125,7 @@ fun HomeView(
     navToProfile: () -> Unit,
     navToFAQ: () -> Unit,
     navToAuditLogs: () -> Unit,
+    navToPlaythrough: () -> Unit,
     padding: PaddingValues = PaddingValues(0.dp),
     sharedTransitionScope: SharedTransitionScope,
     animatedVisibilityScope: AnimatedContentScope,
@@ -204,6 +205,10 @@ fun HomeView(
                                             },
                                             navToFAQ = navToFAQ,
                                             navToAuditLogs = navToAuditLogs,
+                                            navToPlaythrough = {
+                                                coroutineScope.launch { drawerState.close() }
+                                                navToPlaythrough()
+                                            },
                                             sharedTransitionScope = sharedTransitionScope,
                                             animatedVisibilityScope = animatedVisibilityScope,
                                             onOpenPremiumOnboarding = {

--- a/app/src/main/java/com/ilustris/sagai/features/home/ui/HomeView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/home/ui/HomeView.kt
@@ -115,6 +115,7 @@ import kotlinx.coroutines.launch
 import java.util.Calendar
 import kotlin.time.Duration.Companion.seconds
 
+/** Theme and ambient audio are owned by [com.ilustris.sagai.MainActivity] + [com.ilustris.sagai.core.theme.SagaThemeManager], not this screen. */
 @Suppress("ktlint:standard:function-naming")
 @OptIn(ExperimentalAnimationApi::class, ExperimentalSharedTransitionApi::class)
 @Composable

--- a/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/AgenticComponentRenderer.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/AgenticComponentRenderer.kt
@@ -1,5 +1,7 @@
 package com.ilustris.sagai.features.newsaga.ui
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.scaleOut
@@ -18,11 +20,13 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyHorizontalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,6 +34,7 @@ import androidx.compose.foundation.lazy.staggeredgrid.LazyStaggeredGridScope
 import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridItemSpan
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
@@ -49,10 +54,13 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.dropShadow
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.ilustris.sagai.R
 import com.ilustris.sagai.core.ai.model.GenreVisualConfig
@@ -68,7 +76,9 @@ import com.ilustris.sagai.features.newsaga.data.usecase.AgenticUIComponent
 import com.ilustris.sagai.features.newsaga.data.usecase.SagaBook
 import com.ilustris.sagai.features.newsaga.ui.presentation.AgenticAction
 import com.ilustris.sagai.ui.animations.genreVfx
+import com.ilustris.sagai.ui.components.BookGenerationReasoning
 import com.ilustris.sagai.ui.components.CosmicBook
+import com.ilustris.sagai.ui.components.NewSagaBookFocus
 import com.ilustris.sagai.ui.components.CosmicEditorSheet
 import com.ilustris.sagai.ui.components.CosmicInputField
 import com.ilustris.sagai.ui.theme.SagAITheme
@@ -107,14 +117,13 @@ fun AgenticUIComponent.Render(
         is AgenticUIComponent.LibraryComponent -> {
             scope.item(span = StaggeredGridItemSpan.FullLine) {
                 LibraryPager(
-                    this@Render.books,
-                    lockedSaga,
-                    lockedCharacter,
-                    isAgentLoading,
-                    currentAgentMessage =
-                        (this@Render as? AgenticUIComponent.AgentMessage)?.text
-                            ?: "",
-                    onAction,
+                    books = this@Render.books,
+                    lockedSaga = lockedSaga,
+                    lockedCharacter = lockedCharacter,
+                    isAgentLoading = isAgentLoading,
+                    currentAgentMessage = null,
+                    sharedTransitionScope = sharedTransitionScope,
+                    onAction = onAction,
                 )
             }
         }
@@ -255,43 +264,42 @@ private fun IdeaPitchCard(
         val gradient = Brush.verticalGradient(genre.colorPalette(activeVisual))
 
         Column(
-        modifier =
-            modifier
-                .padding(8.dp)
-                .dropShadow(shape) {
-                    this.color = color
-                    this.radius = 10f
-                    this.spread = 5f
-                    this.brush = gradient
-                }
-                .border(1.dp, MaterialTheme.colorScheme.primary, shape)
-                .background(MaterialTheme.colorScheme.surfaceContainer, shape)
-                .clickable { onSelect() }
-                .padding(8.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Icon(
-            painterResource(genre.icon),
-            null,
-            tint = MaterialTheme.colorScheme.onBackground,
-            modifier = Modifier.size(24.dp),
-        )
+            modifier =
+                modifier
+                    .padding(8.dp)
+                    .dropShadow(shape) {
+                        this.color = color
+                        this.radius = 10f
+                        this.spread = 5f
+                        this.brush = gradient
+                    }.border(1.dp, MaterialTheme.colorScheme.primary, shape)
+                    .background(MaterialTheme.colorScheme.surfaceContainer, shape)
+                    .clickable { onSelect() }
+                    .padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                painterResource(genre.icon),
+                null,
+                tint = MaterialTheme.colorScheme.onBackground,
+                modifier = Modifier.size(24.dp),
+            )
 
-        Text(
-            text = idea.title,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
-            textAlign = TextAlign.Start,
-            modifier = Modifier.fillMaxWidth(),
-        )
-        Text(
-            text = idea.description,
-            style = MaterialTheme.typography.bodySmall,
-            textAlign = TextAlign.Start,
-            modifier = Modifier.fillMaxWidth(),
-        )
-    }
+            Text(
+                text = idea.title,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Text(
+                text = idea.description,
+                style = MaterialTheme.typography.bodySmall,
+                textAlign = TextAlign.Start,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
     }
 }
 
@@ -310,122 +318,121 @@ private fun LockedSagaCard(
         val brush = Brush.verticalGradient(genre.colorPalette(activeConfig))
         val genreColor = genre.resolveColor(activeConfig)
         val iconColor = MaterialTheme.colorScheme.secondary
-    var showEditor by remember { mutableStateOf(false) }
+        var showEditor by remember { mutableStateOf(false) }
 
-    Box(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .dropShadow(shape) {
-                    this.color = genreColor
-                    this.radius = 10f
-                    this.spread = 5f
-                    this.brush = brush
-                }
-                .border(1.dp, genreColor.copy(alpha = 0.1f), shape)
-                .clip(shape)
-                .background(genre.color, shape)
-                .background(MaterialTheme.colorScheme.background.copy(alpha = .2f)),
-    ) {
-        Icon(
-            painterResource(genre.icon),
-            null,
-            tint = iconColor,
+        Box(
             modifier =
-                Modifier
-                    .align(Alignment.Center)
-                    .size(100.dp)
-                    .alpha(.1f),
-        )
-
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .dropShadow(shape) {
+                        this.color = genreColor
+                        this.radius = 10f
+                        this.spread = 5f
+                        this.brush = brush
+                    }.border(1.dp, genreColor.copy(alpha = 0.1f), shape)
+                    .clip(shape)
+                    .background(genre.color, shape)
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = .2f)),
         ) {
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-            ) {
-                Icon(
-                    painterResource(R.drawable.round_close_24),
-                    stringResource(R.string.content_description_close),
-                    tint = iconColor,
-                    modifier =
-                        Modifier
-                            .size(24.dp)
-                            .clip(CircleShape)
-                            .clickable { onAction(AgenticAction.UnlockSaga) },
-                )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Button({
-                    showEditor = true
-                }, shape = MaterialTheme.shapes.extraLarge, contentPadding = PaddingValues(8.dp)) {
-                    Text(
-                        stringResource(R.string.edit),
-                        style = MaterialTheme.typography.labelMedium,
-                    )
-                }
-            }
-
-            Text(
-                text = draft.title,
-                style =
-                    MaterialTheme.typography.headlineSmall.copy(
-                        fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        textAlign = TextAlign.Center,
-                    ),
+            Icon(
+                painterResource(genre.icon),
+                null,
+                tint = iconColor,
                 modifier =
                     Modifier
-                        .fillMaxWidth()
-                        .genreVfx(genre),
+                        .align(Alignment.Center)
+                        .size(100.dp)
+                        .alpha(.1f),
             )
 
-            Text(
-                text = draft.description,
-                style =
-                    MaterialTheme.typography.bodyMedium.copy(
-                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                        color = MaterialTheme.colorScheme.onBackground,
-                    ),
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
-    }
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        painterResource(R.drawable.round_close_24),
+                        stringResource(R.string.content_description_close),
+                        tint = iconColor,
+                        modifier =
+                            Modifier
+                                .size(24.dp)
+                                .clip(CircleShape)
+                                .clickable { onAction(AgenticAction.UnlockSaga) },
+                    )
 
-    if (showEditor) {
-        CosmicEditorSheet(
-            title = stringResource(R.string.agentic_edit_saga_title),
-            genre = genre,
-            fields =
-                listOf(
-                    CosmicInputField(
-                        "title",
-                        stringResource(R.string.saga_title_label),
-                        draft.title,
-                        hint = stringResource(R.string.saga_title_hint),
-                    ),
-                    CosmicInputField(
-                        "description",
-                        stringResource(R.string.description_label),
-                        draft.description,
-                        isMultiline = true,
-                        hint = stringResource(R.string.saga_description_hint),
-                    ),
-                ),
-            onSave = {
-                onAction(
-                    AgenticAction.UpdateSaga(
-                        draft.id,
-                        it["title"] ?: draft.title,
-                        it["description"] ?: draft.description,
-                    ),
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    Button({
+                        showEditor = true
+                    }, shape = MaterialTheme.shapes.extraLarge, contentPadding = PaddingValues(8.dp)) {
+                        Text(
+                            stringResource(R.string.edit),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                }
+
+                Text(
+                    text = draft.title,
+                    style =
+                        MaterialTheme.typography.headlineSmall.copy(
+                            fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            textAlign = TextAlign.Center,
+                        ),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .genreVfx(genre),
                 )
-            },
-            onDismiss = { showEditor = false },
-        )
+
+                Text(
+                    text = draft.description,
+                    style =
+                        MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        if (showEditor) {
+            CosmicEditorSheet(
+                title = stringResource(R.string.agentic_edit_saga_title),
+                genre = genre,
+                fields =
+                    listOf(
+                        CosmicInputField(
+                            "title",
+                            stringResource(R.string.saga_title_label),
+                            draft.title,
+                            hint = stringResource(R.string.saga_title_hint),
+                        ),
+                        CosmicInputField(
+                            "description",
+                            stringResource(R.string.description_label),
+                            draft.description,
+                            isMultiline = true,
+                            hint = stringResource(R.string.saga_description_hint),
+                        ),
+                    ),
+                onSave = {
+                    onAction(
+                        AgenticAction.UpdateSaga(
+                            draft.id,
+                            it["title"] ?: draft.title,
+                            it["description"] ?: draft.description,
+                        ),
+                    )
+                },
+                onDismiss = { showEditor = false },
+            )
         }
     }
 }
@@ -509,99 +516,96 @@ private fun CharacterPitchCard(
     modifier: Modifier = Modifier,
 ) {
     SagAITheme(genre = genreVisuals.first) {
-    val genre = genreVisuals.first
+        val genre = genreVisuals.first
         val visualConfig = LocalGenreVisualConfig.current ?: genreVisuals.second
-    val placeholders = LocalGenderPlaceholders.current
-    val silhouetteUrl = placeholders.resolveUrl(genre, persona.gender)
-    val shape = genre.shape(visualConfig)
-    val genreColor = genre.resolveColor(visualConfig)
-
-    Column(
-        modifier =
-            modifier
-                .padding(8.dp)
-                .dropShadow(shape) {
-                    this.color = genreColor
-                    this.radius = 10f
-                    this.spread = 5f
-                    this.brush =
-                        Brush.verticalGradient(genre.colorPalette(visualConfig))
-                }
-                .border(
-                    1.dp,
-                    genreColor.copy(alpha = 0.1f),
-                    shape,
-                )
-                .clip(shape)
-                .background(
-                    MaterialTheme.colorScheme.surfaceContainer,
-                    shape,
-                )
-                .clickable { onSelect() },
-    ) {
-        Box(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .height(180.dp)
-                    .background(genreColor.copy(alpha = 0.1f)),
-        ) {
-            if (silhouetteUrl.isNotEmpty()) {
-                coil3.compose.AsyncImage(
-                    model = silhouetteUrl,
-                    contentDescription = null,
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(16.dp),
-                    contentScale = androidx.compose.ui.layout.ContentScale.Fit,
-                )
-            } else {
-                Icon(
-                    painterResource(genre.icon),
-                    null,
-                    tint = genreColor.copy(alpha = 0.3f),
-                    modifier =
-                        Modifier
-                            .size(80.dp)
-                            .align(Alignment.Center),
-                )
-            }
-        }
+        val placeholders = LocalGenderPlaceholders.current
+        val silhouetteUrl = placeholders.resolveUrl(genre, persona.gender)
+        val shape = genre.shape(visualConfig)
+        val genreColor = genre.resolveColor(visualConfig)
 
         Column(
-            modifier = Modifier.padding(12.dp),
-            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier =
+                modifier
+                    .padding(8.dp)
+                    .dropShadow(shape) {
+                        this.color = genreColor
+                        this.radius = 10f
+                        this.spread = 5f
+                        this.brush =
+                            Brush.verticalGradient(genre.colorPalette(visualConfig))
+                    }.border(
+                        1.dp,
+                        genreColor.copy(alpha = 0.1f),
+                        shape,
+                    ).clip(shape)
+                    .background(
+                        MaterialTheme.colorScheme.surfaceContainer,
+                        shape,
+                    ).clickable { onSelect() },
         ) {
-            Text(
-                text = persona.name,
-                style =
-                    MaterialTheme.typography.titleMedium.copy(
-                        fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
-                        fontWeight = FontWeight.Bold,
-                    ),
-                maxLines = 1,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-            )
-            Text(
-                text = persona.gender.name.lowercase(),
-                style =
-                    MaterialTheme.typography.labelSmall.copy(
-                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                        color = genreColor,
-                    ),
-            )
-            Text(
-                text = persona.description,
-                style =
-                    MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                    ),
-                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
-                maxLines = 3,
-                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
-            )
-        }
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(180.dp)
+                        .background(genreColor.copy(alpha = 0.1f)),
+            ) {
+                if (silhouetteUrl.isNotEmpty()) {
+                    coil3.compose.AsyncImage(
+                        model = silhouetteUrl,
+                        contentDescription = null,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(16.dp),
+                        contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+                    )
+                } else {
+                    Icon(
+                        painterResource(genre.icon),
+                        null,
+                        tint = genreColor.copy(alpha = 0.3f),
+                        modifier =
+                            Modifier
+                                .size(80.dp)
+                                .align(Alignment.Center),
+                    )
+                }
+            }
+
+            Column(
+                modifier = Modifier.padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    text = persona.name,
+                    style =
+                        MaterialTheme.typography.titleMedium.copy(
+                            fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
+                            fontWeight = FontWeight.Bold,
+                        ),
+                    maxLines = 1,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = persona.gender.name.lowercase(),
+                    style =
+                        MaterialTheme.typography.labelSmall.copy(
+                            fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                            color = genreColor,
+                        ),
+                )
+                Text(
+                    text = persona.description,
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                        ),
+                    color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.8f),
+                    maxLines = 3,
+                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis,
+                )
+            }
         }
     }
 }
@@ -615,148 +619,148 @@ private fun LockedCharacterCard(
     modifier: Modifier = Modifier,
 ) {
     SagAITheme(genre = genreVisuals.first) {
-    val genre = genreVisuals.first
+        val genre = genreVisuals.first
         val visualConfig = LocalGenreVisualConfig.current ?: genreVisuals.second
-    val shape = genre.shape(visualConfig)
-    val color = genre.resolveColor(visualConfig)
-    val brush = Brush.verticalGradient(genre.colorPalette(visualConfig))
-    val iconColor = MaterialTheme.colorScheme.secondary
-    var showEditor by remember { mutableStateOf(false) }
+        val shape = genre.shape(visualConfig)
+        val color = genre.resolveColor(visualConfig)
+        val brush = Brush.verticalGradient(genre.colorPalette(visualConfig))
+        val iconColor = MaterialTheme.colorScheme.secondary
+        var showEditor by remember { mutableStateOf(false) }
 
-    val placeholders = LocalGenderPlaceholders.current
-    val silhouetteUrl = placeholders.resolveUrl(genre, persona.gender)
+        val placeholders = LocalGenderPlaceholders.current
+        val silhouetteUrl = placeholders.resolveUrl(genre, persona.gender)
 
-    Box(
-        modifier =
-            modifier
-                .fillMaxWidth()
-                .padding(16.dp)
-                .dropShadow(shape) {
-                    this.color = color
-                    this.radius = 10f
-                    this.spread = 5f
-                    this.brush = brush
-                }
-                .border(1.dp, color.copy(alpha = 0.1f), shape)
-                .clip(shape)
-                .background(genre.color, shape)
-                .background(MaterialTheme.colorScheme.background.copy(alpha = .2f)),
-    ) {
-        if (silhouetteUrl.isNotEmpty()) {
-            coil3.compose.AsyncImage(
-                model = silhouetteUrl,
-                contentDescription = null,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .height(260.dp)
-                        .alpha(0.1f)
-                        .align(Alignment.Center),
-                contentScale = androidx.compose.ui.layout.ContentScale.Fit,
-            )
-        } else {
-            Icon(
-                painterResource(genre.icon),
-                null,
-                tint = iconColor,
-                modifier =
-                    Modifier
-                        .align(Alignment.Center)
-                        .size(50.dp)
-                        .alpha(.4f),
-            )
-        }
-
-        Column(
-            modifier = Modifier.padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp),
+        Box(
+            modifier =
+                modifier
+                    .fillMaxWidth()
+                    .padding(16.dp)
+                    .dropShadow(shape) {
+                        this.color = color
+                        this.radius = 10f
+                        this.spread = 5f
+                        this.brush = brush
+                    }.border(1.dp, color.copy(alpha = 0.1f), shape)
+                    .clip(shape)
+                    .background(genre.color, shape)
+                    .background(MaterialTheme.colorScheme.background.copy(alpha = .2f)),
         ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
+            if (silhouetteUrl.isNotEmpty()) {
+                coil3.compose.AsyncImage(
+                    model = silhouetteUrl,
+                    contentDescription = null,
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(260.dp)
+                            .alpha(0.1f)
+                            .align(Alignment.Center),
+                    contentScale = androidx.compose.ui.layout.ContentScale.Fit,
+                )
+            } else {
                 Icon(
-                    painterResource(R.drawable.round_close_24),
-                    stringResource(R.string.content_description_close),
+                    painterResource(genre.icon),
+                    null,
                     tint = iconColor,
                     modifier =
                         Modifier
-                            .size(24.dp)
-                            .clip(CircleShape)
-                            .clickable { onAction(AgenticAction.UnlockCharacter) },
+                            .align(Alignment.Center)
+                            .size(50.dp)
+                            .alpha(.4f),
                 )
-
-                Spacer(modifier = Modifier.weight(1f))
-
-                Button({
-                    showEditor = true
-                }, shape = MaterialTheme.shapes.extraLarge, contentPadding = PaddingValues(8.dp)) {
-                    Text(
-                        stringResource(R.string.edit),
-                        style = MaterialTheme.typography.labelMedium,
-                    )
-                }
             }
 
-            Text(
-                text = persona.name,
-                style =
-                    MaterialTheme.typography.headlineSmall.copy(
-                        fontWeight = FontWeight.Bold,
-                        fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        textAlign = TextAlign.Center,
-                    ),
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .genreVfx(genre),
-            )
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(
+                        painterResource(R.drawable.round_close_24),
+                        stringResource(R.string.content_description_close),
+                        tint = iconColor,
+                        modifier =
+                            Modifier
+                                .size(24.dp)
+                                .clip(CircleShape)
+                                .clickable { onAction(AgenticAction.UnlockCharacter) },
+                    )
 
-            Text(
-                text = persona.description,
-                style =
-                    MaterialTheme.typography.bodyMedium.copy(
-                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
-                        color = MaterialTheme.colorScheme.onBackground,
+                    Spacer(modifier = Modifier.weight(1f))
+
+                    Button({
+                        showEditor = true
+                    }, shape = MaterialTheme.shapes.extraLarge, contentPadding = PaddingValues(8.dp)) {
+                        Text(
+                            stringResource(R.string.edit),
+                            style = MaterialTheme.typography.labelMedium,
+                        )
+                    }
+                }
+
+                Text(
+                    text = persona.name,
+                    style =
+                        MaterialTheme.typography.headlineSmall.copy(
+                            fontWeight = FontWeight.Bold,
+                            fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
+                            color = MaterialTheme.colorScheme.onBackground,
+                            textAlign = TextAlign.Center,
+                        ),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .genreVfx(genre),
+                )
+
+                Text(
+                    text = persona.description,
+                    style =
+                        MaterialTheme.typography.bodyMedium.copy(
+                            fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                            color = MaterialTheme.colorScheme.onBackground,
+                        ),
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+
+        if (showEditor) {
+            CosmicEditorSheet(
+                title = stringResource(R.string.agentic_edit_character_title),
+                genre = genre,
+                fields =
+                    listOf(
+                        CosmicInputField(
+                            "name",
+                            stringResource(R.string.character_name_label),
+                            persona.name,
+                            hint = stringResource(R.string.character_name_hint),
+                        ),
+                        CosmicInputField(
+                            "description",
+                            stringResource(R.string.biography_label),
+                            persona.description,
+                            isMultiline = true,
+                            hint = stringResource(R.string.character_bio_hint),
+                        ),
                     ),
-                modifier = Modifier.fillMaxWidth(),
+                onSave = {
+                    onAction(
+                        AgenticAction.UpdateCharacter(
+                            persona.id,
+                            it["name"] ?: persona.name,
+                            it["description"] ?: persona.description,
+                        ),
+                    )
+                },
+                onDismiss = { showEditor = false },
             )
         }
     }
-
-    if (showEditor) {
-        CosmicEditorSheet(
-            title = stringResource(R.string.agentic_edit_character_title),
-            genre = genre,
-            fields =
-                listOf(
-                    CosmicInputField(
-                        "name",
-                        stringResource(R.string.character_name_label),
-                        persona.name,
-                        hint = stringResource(R.string.character_name_hint),
-                    ),
-                    CosmicInputField(
-                        "description",
-                        stringResource(R.string.biography_label),
-                        persona.description,
-                        isMultiline = true,
-                        hint = stringResource(R.string.character_bio_hint),
-                    ),
-                ),
-            onSave = {
-                onAction(
-                    AgenticAction.UpdateCharacter(
-                        persona.id,
-                        it["name"] ?: persona.name,
-                        it["description"] ?: persona.description,
-                    ),
-                )
-            },
-            onDismiss = { showEditor = false },
-            )
-    }
-    }
 }
 
+@OptIn(ExperimentalSharedTransitionApi::class)
 @Composable
 fun LibraryPager(
     books: List<Pair<SagaBook, GenreVisualConfig>>,
@@ -764,6 +768,8 @@ fun LibraryPager(
     lockedCharacter: CharacterInfo?,
     isAgentLoading: Boolean,
     currentAgentMessage: String? = null,
+    sharedTransitionScope: SharedTransitionScope? = null,
+    animatedVisibilityScope: AnimatedVisibilityScope? = null,
     onAction: (AgenticAction) -> Unit,
 ) {
     val pagerState =
@@ -793,29 +799,83 @@ fun LibraryPager(
         ) { pageIdx ->
             val bookEntry = books[pageIdx]
             val isOpened = bookEntry.first.draft.id == lockedSaga?.id
+            val isPageLoading = isAgentLoading && isOpened
 
             SagAITheme(genre = bookEntry.first.draft.genre) {
                 val bookVisual = LocalGenreVisualConfig.current ?: bookEntry.second
-            CosmicBook(
-                book = bookEntry.first,
-                    visualConfig = bookVisual,
-                isOpened = isOpened,
-                lockedCharacter = lockedCharacter,
-                isLoading = isAgentLoading && (lockedSaga?.id == bookEntry.first.draft.id),
-                reasoning = if (isAgentLoading && (lockedSaga?.id == bookEntry.first.draft.id)) currentAgentMessage else null,
-                onToggle = {
-                    if (isOpened) {
-                        onAction(AgenticAction.UnlockSaga)
+
+                if (isPageLoading) {
+                    val bookKey = "new-saga-book-${bookEntry.first.draft.id}"
+                    if (sharedTransitionScope != null && animatedVisibilityScope != null) {
+                        with(sharedTransitionScope) {
+                            NewSagaBookFocus(
+                                book = bookEntry.first,
+                                visualConfig = bookVisual,
+                                reasoning = currentAgentMessage,
+                                isOpened = true,
+                                isLoading = true,
+                                lockedCharacter = lockedCharacter,
+                                animatedVisibilityScope = animatedVisibilityScope,
+                                sharedContentKey = bookKey,
+                                onToggle = { onAction(AgenticAction.UnlockSaga) },
+                                onAction = onAction,
+                                modifier = Modifier.fillMaxWidth(),
+                            )
+                        }
                     } else {
-                        onAction(AgenticAction.SelectSaga(bookEntry.first.draft))
+                        Column(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                        ) {
+                            CosmicBook(
+                                book = bookEntry.first,
+                                visualConfig = bookVisual,
+                                isOpened = true,
+                                lockedCharacter = lockedCharacter,
+                                isLoading = true,
+                                reasoning = null,
+                                onToggle = { onAction(AgenticAction.UnlockSaga) },
+                                onAction = onAction,
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(8.dp),
+                            )
+                            BookGenerationReasoning(
+                                reasoning = currentAgentMessage,
+                                genre = bookEntry.first.draft.genre,
+                                visualConfig = bookVisual,
+                                modifier = Modifier.padding(top = 16.dp, start = 8.dp, end = 8.dp),
+                            )
+                        }
                     }
-                },
-                onAction = onAction,
-                modifier =
-                    Modifier
-                        .fillMaxWidth()
-                        .padding(8.dp),
-                )
+                } else {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
+                        CosmicBook(
+                            book = bookEntry.first,
+                            visualConfig = bookVisual,
+                            isOpened = isOpened,
+                            lockedCharacter = lockedCharacter,
+                            isLoading = false,
+                            reasoning = null,
+                            onToggle = {
+                                if (isOpened) {
+                                    onAction(AgenticAction.UnlockSaga)
+                                } else {
+                                    onAction(AgenticAction.SelectSaga(bookEntry.first.draft))
+                                }
+                            },
+                            onAction = onAction,
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .padding(8.dp),
+                        )
+                    }
+                }
             }
         }
 
@@ -863,25 +923,35 @@ fun LibraryPager(
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun UniverseEchoesSection(
     echoes: List<Pair<UniverseEcho, GenreVisualConfig>>,
     onAction: (String) -> Unit,
 ) {
+    val maxSuggestionWidth =
+        (LocalConfiguration.current.screenWidthDp * 0.6f).dp
+
     LazyHorizontalGrid(
         rows = GridCells.Fixed(2),
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(100.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.Bottom),
-        horizontalArrangement = Arrangement.spacedBy(8.dp, Alignment.Start),
+                .heightIn(min = 96.dp, max = 200.dp),
+        contentPadding = PaddingValues(horizontal = 20.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        items(echoes) { (echo, config) ->
-            EchoBubbleCard(echo, config, modifier = Modifier.animateItem()) {
-                onAction(echo.input)
-            }
+        items(
+            items = echoes,
+            key = { (echo, _) -> echo.input },
+        ) { (echo, config) ->
+            EchoBubbleCard(
+                echo = echo,
+                visualConfig = config,
+                maxWidth = maxSuggestionWidth,
+                modifier = Modifier.animateItem(),
+                onClick = { onAction(echo.input) },
+            )
         }
     }
 }
@@ -890,6 +960,7 @@ internal fun UniverseEchoesSection(
 private fun EchoBubbleCard(
     echo: UniverseEcho,
     visualConfig: GenreVisualConfig,
+    maxWidth: Dp,
     modifier: Modifier = Modifier,
     onClick: () -> Unit,
 ) {
@@ -897,40 +968,43 @@ private fun EchoBubbleCard(
         val genre = echo.genre
         val activeVisual = LocalGenreVisualConfig.current ?: visualConfig
         val color = genre.resolveColor(activeVisual)
-    val shape = MaterialTheme.shapes.extraLarge
+        val shape = RoundedCornerShape(25.dp)
         val genreBrush = Brush.linearGradient(genre.colorPalette(activeVisual))
 
-    Row(
-        modifier =
-            modifier
-                .padding(2.dp)
-                .wrapContentSize()
-                .dropShadow(shape) {
-                    brush = genreBrush
-                    radius = 5f
-                    spread = 5f
-                }
-                .clip(shape)
-                .background(MaterialTheme.colorScheme.background)
-                .clickable {
-                    onClick()
-                }
-                .padding(8.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
-        Icon(
-            painterResource(genre.icon),
-            null,
-            tint = color,
-            modifier = Modifier.size(24.dp),
-        )
-        Text(
-            text = echo.input,
-            style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurface,
-        )
-    }
+        val textMaxWidth = maxWidth - 56.dp
+
+        Row(
+            modifier =
+                modifier
+                    .widthIn(max = maxWidth)
+                    .wrapContentWidth(Alignment.Start)
+                    .padding(2.dp)
+                    .dropShadow(shape) {
+                        brush = genreBrush
+                        radius = 5f
+                        spread = 5f
+                    }.clip(shape)
+                    .background(MaterialTheme.colorScheme.background)
+                    .clickable(onClick = onClick)
+                    .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Icon(
+                painterResource(genre.icon),
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(12.dp),
+            )
+            Text(
+                text = echo.input,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurface,
+                modifier = Modifier.widthIn(max = textMaxWidth),
+                softWrap = true,
+                overflow = TextOverflow.Clip,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/NewSagaView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/NewSagaView.kt
@@ -1,9 +1,10 @@
-@file:OptIn(ExperimentalMaterial3Api::class)
+@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalSharedTransitionApi::class)
 
 package com.ilustris.sagai.features.newsaga.ui
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentScope
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.EaseIn
@@ -78,8 +79,8 @@ import com.ilustris.sagai.features.onboarding.data.OnboardingType
 import com.ilustris.sagai.features.onboarding.ui.OnboardingDialog
 import com.ilustris.sagai.ui.animations.chromaticAberration
 import com.ilustris.sagai.ui.animations.divineAura
-import com.ilustris.sagai.ui.components.CosmicBook
 import com.ilustris.sagai.ui.components.GenreMemoriesLoader
+import com.ilustris.sagai.ui.components.NewSagaBookFocus
 import com.ilustris.sagai.ui.theme.FluidGradient
 import com.ilustris.sagai.ui.theme.fadedGradientTopAndBottom
 import com.ilustris.sagai.ui.theme.gradientFill
@@ -107,8 +108,8 @@ fun NewSagaView(
     val currentConfig by viewModel.currentConfig.collectAsStateWithLifecycle()
     val genderPlaceholders by viewModel.genderPlaceholders.collectAsStateWithLifecycle()
     val universeEchoes by viewModel.universeEchoes.collectAsStateWithLifecycle()
-    val isEchoLoading by viewModel.isEchoLoading.collectAsStateWithLifecycle()
     var userInput by remember { mutableStateOf("") }
+    val defaultCreationMessage = stringResource(R.string.saga_description_subtitle)
     val genreConfigs by viewModel.genresVisuals.collectAsStateWithLifecycle()
     val libraryBooks by viewModel.libraryBooks.collectAsStateWithLifecycle()
     val uiError by viewModel.uiError.collectAsStateWithLifecycle()
@@ -131,34 +132,13 @@ fun NewSagaView(
     ) {
         val currentPalette = lockedSaga?.genre?.colorPalette() ?: holographicGradient
 
-        AnimatedContent(isEchoLoading) {
-            if (it) {
-                Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                    with(sharedTransitionScope) {
-                        Image(
-                            painterResource(R.drawable.ic_spark),
-                            contentDescription = "Loading",
-                            modifier =
-                                Modifier
-                                    .size(100.dp)
-                                    .sharedElement(
-                                        rememberSharedContentState("spark_icon"),
-                                        animatedVisibilityScope,
-                                    ).gradientFill(Brush.verticalGradient(holographicGradient))
-                                    .reactiveShimmer(true)
-                                    .levitate()
-                                    .divineAura(),
-                        )
-                    }
-                }
-            } else {
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.colorScheme.background)
-                            .imePadding(),
-                ) {
+        Box(
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .imePadding(),
+        ) {
                     AnimatedContent(
                         currentPalette,
                         label = "GradientTransition",
@@ -200,105 +180,107 @@ fun NewSagaView(
                             )
                         }
 
-                        AnimatedVisibility(libraryBooks.isNotEmpty() && isSaving.not()) {
-                            val filteredBooks =
-                                if (isSaving) {
-                                    libraryBooks.filter { it.first.draft.id == lockedSaga?.id }
-                                } else {
-                                    libraryBooks
-                                }
-                            LibraryPager(
-                                books = filteredBooks,
-                                lockedSaga = lockedSaga,
-                                lockedCharacter = lockedCharacter,
-                                isAgentLoading = isAgentLoading || isSaving,
-                                currentAgentMessage = currentAgentMessage,
-                                onAction = viewModel::onAgenticAction,
-                            )
-                        }
-
-                        AnimatedVisibility(
-                            isSaving,
-                            modifier = Modifier.align(Alignment.CenterHorizontally),
-                            enter =
-                                fadeIn(tween(800)) +
-                                    scaleIn(
-                                        tween(
-                                            400,
-                                            easing = FastOutLinearInEasing,
-                                        ),
-                                    ),
-                            exit = scaleOut(),
-                        ) {
-                            val actualBook =
-                                libraryBooks.firstOrNull { it.first.draft.id == lockedSaga?.id }
-                            actualBook?.let {
-                                CosmicBook(
-                                    book = it.first,
-                                    visualConfig = it.second,
-                                    isOpened = true,
-                                    isLoading = true,
-                                    reasoning = currentAgentMessage,
-                                    onToggle = {},
-                                    onAction = {},
-                                    modifier =
-                                        Modifier
-                                            .padding(50.dp)
-                                            .levitate()
-                                            .divineAura()
-                                            .chromaticAberration(),
-                                )
-                            }
-                        }
-
-                        AnimatedVisibility(
-                            isAgentLoading && libraryBooks.isEmpty(),
+                        Box(
                             modifier =
                                 Modifier
-                                    .fillMaxWidth()
-                                    .fillMaxHeight(.6f),
+                                    .weight(1f)
+                                    .fillMaxWidth(),
+                            contentAlignment = Alignment.Center,
                         ) {
-                            GenreMemoriesLoader(
-                                isLoading = isAgentLoading,
-                                message = emptyString(),
-                                genresConfigs = genreConfigs ?: emptyList(),
-                            )
-                        }
+                            when {
+                                isSaving -> {
+                                    val actualBook =
+                                        libraryBooks.firstOrNull {
+                                            it.first.draft.id == lockedSaga?.id
+                                        }
+                                    actualBook?.let { entry ->
+                                        with(sharedTransitionScope) {
+                                            NewSagaBookFocus(
+                                                book = entry.first,
+                                                visualConfig = entry.second,
+                                                reasoning = currentAgentMessage,
+                                                isOpened = true,
+                                                isLoading = true,
+                                                animatedVisibilityScope = animatedVisibilityScope,
+                                                sharedContentKey = "new-saga-book-${entry.first.draft.id}",
+                                                modifier = Modifier.fillMaxSize(),
+                                            )
+                                        }
+                                    }
+                                }
 
-                        AnimatedContent(currentAgentMessage, transitionSpec = {
-                            fadeIn() + slideInVertically { it / 2 } togetherWith fadeOut() + slideOutVertically { -it / 2 }
-                        }, modifier = Modifier.fillMaxWidth()) { message ->
-                            message?.let {
-                                Text(
-                                    text = it,
-                                    style =
-                                        MaterialTheme.typography.bodyMedium.copy(
-                                            shadow =
-                                                Shadow(
-                                                    Color.White,
-                                                    blurRadius = 10f,
-                                                ),
-                                        ),
-                                    modifier =
-                                        Modifier
-                                            .padding(16.dp)
-                                            .fillMaxWidth()
-                                            .levitate(isAgentLoading),
-                                    textAlign = TextAlign.Center,
-                                )
+                                libraryBooks.isNotEmpty() -> {
+                                    LibraryPager(
+                                        books = libraryBooks,
+                                        lockedSaga = lockedSaga,
+                                        lockedCharacter = lockedCharacter,
+                                        isAgentLoading = isAgentLoading,
+                                        currentAgentMessage = currentAgentMessage,
+                                        sharedTransitionScope = sharedTransitionScope,
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        onAction = viewModel::onAgenticAction,
+                                    )
+                                }
+
+                                isAgentLoading -> {
+                                    GenreMemoriesLoader(
+                                        isLoading = isAgentLoading,
+                                        reasoning = currentAgentMessage,
+                                        genresConfigs = genreConfigs ?: emptyList(),
+                                        modifier = Modifier.fillMaxSize(),
+                                    )
+                                }
+
+                                else -> {
+                                    Column(
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = 24.dp),
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                        verticalArrangement = Arrangement.Center,
+                                    ) {
+                                        AnimatedContent(
+                                            targetState = currentAgentMessage ?: defaultCreationMessage,
+                                            transitionSpec = {
+                                                fadeIn() + slideInVertically { it / 2 } togetherWith
+                                                    fadeOut() + slideOutVertically { -it / 2 }
+                                            },
+                                            modifier = Modifier.fillMaxWidth(),
+                                        ) { message ->
+                                            Text(
+                                                text = message,
+                                                style =
+                                                    MaterialTheme.typography.bodyMedium.copy(
+                                                        shadow =
+                                                            Shadow(
+                                                                Color.White,
+                                                                blurRadius = 10f,
+                                                            ),
+                                                    ),
+                                                modifier =
+                                                    Modifier
+                                                        .fillMaxWidth()
+                                                        .levitate(isAgentLoading),
+                                                textAlign = TextAlign.Center,
+                                            )
+                                        }
+
+                                        uiError?.let {
+                                            Text(
+                                                text = it,
+                                                color = MaterialTheme.colorScheme.error,
+                                                style = MaterialTheme.typography.labelSmall,
+                                                modifier = Modifier.padding(top = 12.dp),
+                                                textAlign = TextAlign.Center,
+                                            )
+                                        }
+                                    }
+                                }
                             }
                         }
-
-                        uiError?.let {
-                            Text(
-                                text = it,
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.labelSmall,
-                                modifier = Modifier.padding(16.dp),
-                                textAlign = TextAlign.Center,
-                            )
-                        }
                     }
+
                     Box(
                         modifier =
                             Modifier
@@ -380,8 +362,6 @@ fun NewSagaView(
                             }
                         }
                     }
-                }
-            }
         }
     }
 
@@ -427,7 +407,7 @@ fun PromptBar(
     isLoading: Boolean,
     genre: Genre?,
 ) {
-    val shape = sagaShape() ?: MaterialTheme.shapes.extraLarge
+    val shape = MaterialTheme.shapes.extraLarge
     val themeBrush =
         Brush.horizontalGradient(genre?.colorPalette() ?: holographicGradient)
 

--- a/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/presentation/NewSagaViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/newsaga/ui/presentation/NewSagaViewModel.kt
@@ -6,6 +6,7 @@ import com.ilustris.sagai.core.ai.model.GenreVisualConfig
 import com.ilustris.sagai.core.ai.services.GenreVisualConfigService
 import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.core.services.getGenderPlaceholders
+import com.ilustris.sagai.core.data.isFlowCancellation
 import com.ilustris.sagai.core.utils.toJsonFormat
 import com.ilustris.sagai.features.characters.data.model.Character
 import com.ilustris.sagai.features.characters.data.model.CharacterInfo
@@ -24,6 +25,7 @@ import com.ilustris.sagai.features.newsaga.data.usecase.SagaCreationState
 import com.ilustris.sagai.ui.navigation.ChatKey
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -127,9 +129,6 @@ class NewSagaViewModel
         private val _isAgentLoading = MutableStateFlow(false)
         val isAgentLoading = _isAgentLoading.asStateFlow()
 
-        private val _isEchoLoading = MutableStateFlow(false)
-        val isEchoLoading = _isEchoLoading.asStateFlow()
-
         private val _libraryBooks =
             MutableStateFlow<List<Pair<SagaBook, GenreVisualConfig>>>(emptyList())
         val libraryBooks = _libraryBooks.asStateFlow()
@@ -162,30 +161,55 @@ class NewSagaViewModel
 
         private var assistJob: kotlinx.coroutines.Job? = null
 
+        private var initialEchoesJob: Job? = null
+
+        /** Bumped when the user starts creation so late echo responses are ignored. */
+        private var echoesRequestGeneration = 0
+
         init {
             preFetchVisualConfigs()
             fetchGenderPlaceholders()
             requestInitialEchoes()
         }
 
+        private fun cancelInitialEchoes() {
+            echoesRequestGeneration++
+            initialEchoesJob?.cancel()
+            initialEchoesJob = null
+        }
+
         private fun requestInitialEchoes() {
-            _isEchoLoading.value = true
-            viewModelScope.launch {
-                newSagaUseCase
-                    .provideInitialEchoes()
-                    .onSuccessAsync {
-                        _universeEchoes.value =
-                            it.suggestions.mapNotNull { echo ->
-                                val config = visualConfigService.getVisualConfig(echo.genre)
-                                if (config != null) echo to config else null
+            val generation = echoesRequestGeneration
+            initialEchoesJob?.cancel()
+            initialEchoesJob =
+                viewModelScope.launch {
+                    try {
+                        newSagaUseCase
+                            .provideInitialEchoes()
+                            .onSuccessAsync {
+                                if (generation != echoesRequestGeneration || _isAgentLoading.value) {
+                                    return@onSuccessAsync
+                                }
+                                _universeEchoes.value =
+                                    it.suggestions.mapNotNull { echo ->
+                                        val config = visualConfigService.getVisualConfig(echo.genre)
+                                        if (config != null) echo to config else null
+                                    }
+                                _currentAgentMessage.value = it.message
+                            }.onFailureAsync {
+                                if (generation != echoesRequestGeneration || _isAgentLoading.value) {
+                                    return@onFailureAsync
+                                }
+                                _uiError.value = it.localizedMessage
                             }
-                        _currentAgentMessage.value = it.message
-                        _isEchoLoading.value = false
-                    }.onFailure {
-                        _uiError.value = it.localizedMessage
-                        _isEchoLoading.value = false
+                    } catch (e: Exception) {
+                        if (e.isFlowCancellation()) {
+                            Timber.d("Initial universe echoes cancelled — prioritizing user prompt")
+                            return@launch
+                        }
+                        throw e
                     }
-            }
+                }
         }
 
         private fun fetchGenderPlaceholders() {
@@ -421,6 +445,7 @@ class NewSagaViewModel
 
         private fun submitUserPrompt(prompt: String) {
             if (prompt.isBlank()) return
+            cancelInitialEchoes()
             _universeEchoes.value = emptyList()
             _libraryBooks.value = emptyList()
             _selectedBook.value = null

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManager.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManager.kt
@@ -32,7 +32,7 @@ interface ChatNotificationManager {
         largeIcon: Bitmap?,
     )
 
-    fun sendSnackBarNotification(
+    fun deliverSystemNotification(
         saga: SagaMetadata,
         event: SagaNotificationEvent,
     )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManagerImpl.kt
@@ -188,20 +188,20 @@ class ChatNotificationManagerImpl
 
             when (event.style) {
                 NotificationStyle.CHAT -> {
-                    /*sendChatNotification(
+                    sendChatNotification(
                         saga = saga.data,
                         title = saga.data.title,
+                        character = null,
                         message = event.message,
-                        largeIcon = event.largeIcon,
-                        pendingIntent = createPendingIntent(formatChatDeepLink),
-                    )*/
+                        largeIcon = event.icon ?: event.largeIcon,
+                    )
                 }
 
                 NotificationStyle.DEFAULT -> {
                     sendToNotificationChannel(
                         title = saga.data.title,
                         content = event.message,
-                        largeIcon = event.largeIcon,
+                        largeIcon = event.largeIcon ?: event.icon,
                         pendingIntent = createPendingIntent(formatChatDeepLink),
                         genreColor = saga.data.genre.resolveColor(null),
                         smallIconResId = R.drawable.ic_spark,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/ChatNotificationManagerImpl.kt
@@ -51,15 +51,8 @@ class ChatNotificationManagerImpl
             saga: SagaContent,
             message: MessageContent,
         ) {
-            if (appLifecycleManager.isAppInForeground.value) {
-                Timber.i(
-                    "App is in foreground. Skipping notification for message: ${message.message.text}",
-                )
-                return
-            }
-
             Timber.i(
-                "App is in background. Proceeding with notification for message: ${message.message.text}",
+                "Delivering system message notification: ${message.message.text}",
             )
 
             val characterIcon =
@@ -85,16 +78,7 @@ class ChatNotificationManagerImpl
             smallIcon: Bitmap?,
             largeIcon: Bitmap?,
         ) {
-            if (appLifecycleManager.isAppInForeground.value) {
-                Timber.i(
-                    "App is in foreground. Skipping notification for: $title",
-                )
-                return
-            }
-
-            Timber.i(
-                "App is in background. Proceeding with notification: $title",
-            )
+            Timber.i("Delivering system notification: $title")
 
             val formatChatDeepLink = "saga://chat/${saga.id}/false"
 
@@ -171,20 +155,15 @@ class ChatNotificationManagerImpl
 
         private fun chatDeepLink(sagaId: String): String = "saga://chat/$sagaId/false"
 
-        override fun sendSnackBarNotification(
+        override fun deliverSystemNotification(
             saga: com.ilustris.sagai.features.home.data.model.SagaMetadata,
             event: SagaNotificationEvent,
         ) {
-            if (appLifecycleManager.isAppInForeground.value) {
-                Timber.i("App is in foreground. Skipping background notification.")
-                return
-            }
-
             Timber.i(
-                "App is in background. Sending notification with style: ${event.style}",
+                "Delivering system notification (${event.style}) for saga ${event.sagaId}",
             )
 
-            val formatChatDeepLink = "saga://chat/${saga.data.id}/false"
+            val formatChatDeepLink = "saga://chat/${event.sagaId}/false"
 
             when (event.style) {
                 NotificationStyle.CHAT -> {
@@ -199,7 +178,7 @@ class ChatNotificationManagerImpl
 
                 NotificationStyle.DEFAULT -> {
                     sendToNotificationChannel(
-                        title = saga.data.title,
+                        title = event.sagaTitle,
                         content = event.message,
                         largeIcon = event.largeIcon ?: event.icon,
                         pendingIntent = createPendingIntent(formatChatDeepLink),

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/NarrativeActionExecutorImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/NarrativeActionExecutorImpl.kt
@@ -21,6 +21,7 @@ import com.ilustris.sagai.features.saga.datasource.MessageDao
 import com.ilustris.sagai.features.timeline.data.model.Timeline
 import com.ilustris.sagai.features.timeline.data.model.TimelineContent
 import com.ilustris.sagai.features.timeline.domain.TimelineUseCase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import timber.log.Timber
 import javax.inject.Inject
@@ -181,31 +182,26 @@ class NarrativeActionExecutorImpl
             val saga = environment.getSagaMetadata() ?: error("Saga not available")
             environment.dismissMilestone()
             var generated: GeneratedContent<Chapter>? = null
-            val contextString = "Synthesizing chapter progression and weaving plot threads..."
-            val style = genreConfigService.conversationBlueprint(saga.data.genre)
-            reasoningSynthesizerService
-                .synthesizeReasoning(
-                    sourceFlow = chapterUseCase.synthesizeChapterEvolutionStream(chapter.data.id),
-                    context = contextString,
-                    conversationStyle = style,
-                    genre = saga.data.genre.name,
-                ).collect { state ->
-                    when (state) {
-                        is StreamingState.Reasoning -> {
-                            environment.onReasoningChunk(state.chunk)
-                        }
+            chapterUseCase.synthesizeChapterEvolutionStream(chapter.data.id).collect { state ->
+                when (state) {
+                    is StreamingState.Reasoning -> {
+                        environment.onReasoningChunk(state.chunk)
+                    }
 
-                        is StreamingState.Success -> {
-                            generated = state.data
-                            environment.onReasoningChunk(null)
-                        }
+                    is StreamingState.Success -> {
+                        generated = state.data
+                        environment.onReasoningChunk(null)
+                    }
 
-                        is StreamingState.Error -> {
-                            environment.onReasoningChunk(null)
-                            error(state.message)
+                    is StreamingState.Error -> {
+                        environment.onReasoningChunk(null)
+                        if (state.isFlowCancellation()) {
+                            throw CancellationException(state.message)
                         }
+                        error(state.message)
                     }
                 }
+            }
             generated ?: error("Failed to generate chapter synthesis")
         }
 
@@ -268,35 +264,26 @@ class NarrativeActionExecutorImpl
             } else {
                 environment.dismissMilestone()
                 var generated: GeneratedContent<Timeline>? = null
-                val contextString = "Evaluating actions and shaping consequences..."
-                val style = genreConfigService.conversationBlueprint(saga.data.genre)
-                reasoningSynthesizerService
-                    .synthesizeReasoning(
-                        sourceFlow =
-                            timelineUseCase.generateFullLoreUpdateStream(
-                                saga,
-                                timeline.data,
-                            ),
-                        context = contextString,
-                        conversationStyle = style,
-                        genre = saga.data.genre.name,
-                    ).collect { state ->
-                        when (state) {
-                            is StreamingState.Reasoning -> {
-                                environment.onReasoningChunk(state.chunk)
-                            }
+                timelineUseCase.generateFullLoreUpdateStream(saga, timeline.data).collect { state ->
+                    when (state) {
+                        is StreamingState.Reasoning -> {
+                            environment.onReasoningChunk(state.chunk)
+                        }
 
-                            is StreamingState.Success -> {
-                                generated = state.data
-                                environment.onReasoningChunk(null)
-                            }
+                        is StreamingState.Success -> {
+                            generated = state.data
+                            environment.onReasoningChunk(null)
+                        }
 
-                            is StreamingState.Error -> {
-                                environment.onReasoningChunk(null)
-                                error(state.message)
+                        is StreamingState.Error -> {
+                            environment.onReasoningChunk(null)
+                            if (state.isFlowCancellation()) {
+                                throw CancellationException(state.message)
                             }
+                            error(state.message)
                         }
                     }
+                }
                 generated ?: error("Failed to generate timeline update")
             }
         }
@@ -330,35 +317,26 @@ class NarrativeActionExecutorImpl
                 environment.dismissMilestone()
                 var generated: GeneratedContent<Act>? = null
                 val fullSaga = environment.getSagaContent() ?: error("Saga content not available")
-                val contextString = "Judging the player's choices and concluding the act..."
-                val style = genreConfigService.conversationBlueprint(saga.data.genre)
-                reasoningSynthesizerService
-                    .synthesizeReasoning(
-                        sourceFlow =
-                            actUseCase.synthesizeActEvolutionStream(
-                                fullSaga,
-                                currentAct,
-                            ),
-                        context = contextString,
-                        conversationStyle = style,
-                        genre = saga.data.genre.name,
-                    ).collect { state ->
-                        when (state) {
-                            is StreamingState.Reasoning -> {
-                                environment.onReasoningChunk(state.chunk)
-                            }
+                actUseCase.synthesizeActEvolutionStream(fullSaga, currentAct).collect { state ->
+                    when (state) {
+                        is StreamingState.Reasoning -> {
+                            environment.onReasoningChunk(state.chunk)
+                        }
 
-                            is StreamingState.Success -> {
-                                generated = state.data
-                                environment.onReasoningChunk(null)
-                            }
+                        is StreamingState.Success -> {
+                            generated = state.data
+                            environment.onReasoningChunk(null)
+                        }
 
-                            is StreamingState.Error -> {
-                                environment.onReasoningChunk(null)
-                                error(state.message)
+                        is StreamingState.Error -> {
+                            environment.onReasoningChunk(null)
+                            if (state.isFlowCancellation()) {
+                                throw CancellationException(state.message)
                             }
+                            error(state.message)
                         }
                     }
+                }
                 generated ?: error("Failed to generate act synthesis")
             }
         }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManager.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManager.kt
@@ -82,6 +82,9 @@ interface SagaContentManager {
 
     fun stopProcessing()
 
+    /** Clears narrative/milestone/processing state when leaving or switching sagas. */
+    fun resetSagaSession()
+
     suspend fun updateSummary(sceneSummary: SceneSummary)
 
     suspend fun getSagaContent(): SagaContent?

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -449,14 +449,12 @@ class SagaContentManagerImpl
                         .getImageBitmap(lastMessage.character?.image, true)
                         .getSuccess()
                 if (lastMessage.message.senderType == SenderType.CHARACTER) {
-                    emitNotification(
-                        SagaNotificationEvent(
-                            message =
-                                "${lastMessage.message.speakerName ?: emptyString()}: ${lastMessage.message.text}",
-                            icon = charIcon,
-                            style = NotificationStyle.CHAT,
-                        ),
-                    )
+                    notificationEvent(
+                        message =
+                            "${lastMessage.message.speakerName ?: emptyString()}: ${lastMessage.message.text}",
+                        icon = charIcon,
+                        style = NotificationStyle.CHAT,
+                    )?.let { emitNotification(it) }
                 }
             }
         }
@@ -643,6 +641,22 @@ class SagaContentManagerImpl
             }
         }
 
+        private fun notificationEvent(
+            message: String,
+            style: NotificationStyle,
+            icon: android.graphics.Bitmap? = null,
+        ): SagaNotificationEvent? {
+            val saga = content.value ?: return null
+            return SagaNotificationEvent(
+                sagaId = saga.data.id,
+                sagaTitle = saga.data.title,
+                genre = saga.data.genre,
+                message = message,
+                icon = icon,
+                style = style,
+            )
+        }
+
         private fun emitNotification(event: SagaNotificationEvent) {
             managerScope.launch {
                 notificationUpdate.emit(event)
@@ -737,54 +751,38 @@ class SagaContentManagerImpl
                 milestoneUpdate.emit(milestone)
             }
 
-        private fun milestoneBackgroundNotification(milestone: SagaMilestone): SagaNotificationEvent? =
-            when (milestone) {
-                is SagaMilestone.ChapterFinished ->
-                    SagaNotificationEvent(
-                        message =
-                            context.getString(
-                                R.string.notification_new_chapter_content,
-                                milestone.chapter.title,
-                            ),
-                        style = NotificationStyle.DEFAULT,
-                    )
+        private fun milestoneBackgroundNotification(milestone: SagaMilestone): SagaNotificationEvent? {
+            val message =
+                when (milestone) {
+                    is SagaMilestone.ChapterFinished ->
+                        context.getString(
+                            R.string.notification_new_chapter_content,
+                            milestone.chapter.title,
+                        )
 
-                is SagaMilestone.ActFinished ->
-                    SagaNotificationEvent(
-                        message =
-                            context.getString(
-                                R.string.notification_new_act_content,
-                                milestone.act.title,
-                                milestone.act.title,
-                            ),
-                        style = NotificationStyle.DEFAULT,
-                    )
+                    is SagaMilestone.ActFinished ->
+                        context.getString(
+                            R.string.notification_new_act_content,
+                            milestone.act.title,
+                            milestone.act.title,
+                        )
 
-                is SagaMilestone.NewEvent ->
-                    SagaNotificationEvent(
-                        message =
-                            context.getString(
-                                R.string.notification_timeline_event_content,
-                                milestone.timeline.title,
-                            ),
-                        style = NotificationStyle.DEFAULT,
-                    )
+                    is SagaMilestone.NewEvent ->
+                        context.getString(
+                            R.string.notification_timeline_event_content,
+                            milestone.timeline.title,
+                        )
 
-                is SagaMilestone.NewCharacter -> {
-                    val name =
-                        "${milestone.character.name} ${milestone.character.lastName ?: emptyString()}".trim()
-                    SagaNotificationEvent(
-                        message =
-                            context.getString(
-                                R.string.notification_new_character_content,
-                                name,
-                            ),
-                        style = NotificationStyle.DEFAULT,
-                    )
+                    is SagaMilestone.NewCharacter -> {
+                        val name =
+                            "${milestone.character.name} ${milestone.character.lastName ?: emptyString()}".trim()
+                        context.getString(R.string.notification_new_character_content, name)
+                    }
+
+                    else -> return null
                 }
-
-                else -> null
-            }
+            return notificationEvent(message, NotificationStyle.DEFAULT)
+        }
 
         private suspend fun startProcessing(block: suspend () -> Unit) {
             if (isProcessing.get().not()) {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -13,6 +13,7 @@ import com.ilustris.sagai.core.file.BackupService
 import com.ilustris.sagai.core.file.ImageHelper
 import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.core.services.getNarrativeRules
+import com.ilustris.sagai.core.theme.SagaImmersiveSession
 import com.ilustris.sagai.core.theme.SagaThemeManager
 import com.ilustris.sagai.core.utils.doNothing
 import com.ilustris.sagai.core.utils.emptyString
@@ -100,6 +101,7 @@ class SagaContentManagerImpl
         private val genreConfigService: GenreConfigService,
         private val messageDao: MessageDao,
         private val sagaThemeManager: SagaThemeManager,
+        private val sagaImmersiveSession: SagaImmersiveSession,
         private val narrativeCoordinator: NarrativeCoordinator,
         private val narrativeActionExecutor: NarrativeActionExecutor,
         @ApplicationContext
@@ -367,7 +369,9 @@ class SagaContentManagerImpl
                                     _sceneSummary.value = it
                                 }
 
-                                sagaThemeManager.updateTheme(saga.data.genre)
+                                if (sagaImmersiveSession.isSagaActive(saga.data.id)) {
+                                    sagaThemeManager.updateTheme(saga.data.genre)
+                                }
 
                                 checkMessageNotifications(
                                     previousSaga,
@@ -728,8 +732,58 @@ class SagaContentManagerImpl
                     if (milestone.shouldPlaySoundFx) {
                         sagaThemeManager.playVfx()
                     }
+                    milestoneBackgroundNotification(milestone)?.let { emitNotification(it) }
                 }
                 milestoneUpdate.emit(milestone)
+            }
+
+        private fun milestoneBackgroundNotification(milestone: SagaMilestone): SagaNotificationEvent? =
+            when (milestone) {
+                is SagaMilestone.ChapterFinished ->
+                    SagaNotificationEvent(
+                        message =
+                            context.getString(
+                                R.string.notification_new_chapter_content,
+                                milestone.chapter.title,
+                            ),
+                        style = NotificationStyle.DEFAULT,
+                    )
+
+                is SagaMilestone.ActFinished ->
+                    SagaNotificationEvent(
+                        message =
+                            context.getString(
+                                R.string.notification_new_act_content,
+                                milestone.act.title,
+                                milestone.act.title,
+                            ),
+                        style = NotificationStyle.DEFAULT,
+                    )
+
+                is SagaMilestone.NewEvent ->
+                    SagaNotificationEvent(
+                        message =
+                            context.getString(
+                                R.string.notification_timeline_event_content,
+                                milestone.timeline.title,
+                            ),
+                        style = NotificationStyle.DEFAULT,
+                    )
+
+                is SagaMilestone.NewCharacter -> {
+                    val name =
+                        "${milestone.character.name} ${milestone.character.lastName ?: emptyString()}".trim()
+                    SagaNotificationEvent(
+                        message =
+                            context.getString(
+                                R.string.notification_new_character_content,
+                                name,
+                            ),
+                        style = NotificationStyle.DEFAULT,
+                    )
+                }
+
+                else -> null
             }
 
         private suspend fun startProcessing(block: suspend () -> Unit) {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -43,6 +43,8 @@ import com.ilustris.sagai.features.home.data.model.getCurrentTimeLine
 import com.ilustris.sagai.features.home.data.usecase.SagaHistoryUseCase
 import com.ilustris.sagai.features.saga.chat.data.model.Message
 import com.ilustris.sagai.features.saga.chat.data.model.SceneSummary
+import com.ilustris.sagai.features.saga.chat.data.model.hasActiveSceneSummary
+import com.ilustris.sagai.features.saga.chat.data.model.shouldEnsureSceneSummary
 import com.ilustris.sagai.features.saga.chat.data.model.SenderType
 import com.ilustris.sagai.features.saga.chat.domain.manager.BackgroundTask
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeAction
@@ -146,6 +148,8 @@ class SagaContentManagerImpl
 
         private var progressionCounter = 0
 
+        private var objectiveEnsureJob: kotlinx.coroutines.Job? = null
+
         private fun setNarrativeProcessingStatus(isProcessing: Boolean) {
             isProcessingNarrative.set(isProcessing)
             _narrativeProcessingUiState.value = isProcessing
@@ -188,7 +192,9 @@ class SagaContentManagerImpl
                     is NarrativeExecutionResult.Success -> {
                         handlePostAction(sagaMetadata, action, result.value)
                         awaitMilestoneDismissalIfNeeded()
-                        requestNarrativeProgression(isRetry = false)
+                        managerScope.launch {
+                            requestNarrativeProgression(isRetry = false)
+                        }
                     }
 
                     is NarrativeExecutionResult.Failure -> {
@@ -250,6 +256,9 @@ class SagaContentManagerImpl
             if (isMilestoneActive.value) {
                 isMilestoneActive.first { !it }
             }
+            if (milestoneUpdate.value?.isIntrusive == true) {
+                milestoneUpdate.first { it == null || !it.isIntrusive }
+            }
         }
 
         override suspend fun updatePlaytime(
@@ -276,6 +285,24 @@ class SagaContentManagerImpl
             }
         }
 
+        override fun resetSagaSession() {
+            Timber.d("resetSagaSession: clearing chat session state")
+            sagaJob?.cancel()
+            sagaJob = null
+            objectiveEnsureJob?.cancel()
+            objectiveEnsureJob = null
+            setNarrativeProcessingStatus(false)
+            isProcessing.set(false)
+            narrativeCoordinator.reset()
+            contentReasoning.value = null
+            _sceneSummary.value = null
+            isMilestoneActive.value = false
+            milestoneUpdate.value = null
+            notificationUpdate.value = null
+            isOnboardingVisible.value = false
+            content.value = null
+        }
+
         override suspend fun loadSaga(sagaId: String) {
             if (content.value
                     ?.data
@@ -288,11 +315,10 @@ class SagaContentManagerImpl
                 }
                 return
             }
-            sagaJob?.cancel()
+            resetSagaSession()
             sagaJob =
                 managerScope.launch {
                     Timber.d("Loading saga: $sagaId")
-                    content.value = null
                     try {
                         if (loadingObserverJob == null || loadingObserverJob?.isActive == false) {
                             loadingObserverJob = observeLoading()
@@ -372,6 +398,7 @@ class SagaContentManagerImpl
                                 saga.getCurrentTimeLine()?.data?.sceneSummary?.let {
                                     _sceneSummary.value = it
                                 }
+                                ensureCurrentTimelineSceneSummary(saga)
 
                                 if (sagaImmersiveSession.isOwnerOnTop("chat")) {
                                     sagaThemeManager.updateTheme(saga.data.genre)
@@ -563,8 +590,14 @@ class SagaContentManagerImpl
         private fun observeReasoning() =
             managerScope.launch {
                 contentReasoning.collectLatest { reasoning ->
-                    if (reasoning != null && milestoneUpdate.value != SagaMilestone.Loading) {
-                        emitMilestone(SagaMilestone.Loading)
+                    when {
+                        reasoning != null && milestoneUpdate.value != SagaMilestone.Loading -> {
+                            emitMilestone(SagaMilestone.Loading)
+                        }
+
+                        reasoning == null && milestoneUpdate.value is SagaMilestone.Loading -> {
+                            emitMilestone(null)
+                        }
                     }
                 }
             }
@@ -595,6 +628,8 @@ class SagaContentManagerImpl
 
             progressionMutex.withLock {
                 val currentSaga = content.value ?: fallbackSaga ?: return@withLock
+
+                ensureCurrentTimelineSceneSummary(currentSaga)
 
                 if (isProcessingNarrative.get()) {
                     Timber.i("requestNarrativeProgression: narrative processing, skipping.")
@@ -631,12 +666,12 @@ class SagaContentManagerImpl
                         context = buildEvaluationContext(),
                     )
 
-                if (uiState.phase is NarrativePhase.BackgroundProcessing &&
-                    hydrated is NarrativeAction.CloseTimeline
-                ) {
-                    Timber.d("Auto-executing CloseTimeline")
-                    narrativeCoordinator.onBackgroundTaskStarted(BackgroundTask.ClosingScene)
-                    executeNarrativeAction(hydrated, isRetry = isRetry)
+                if (hydrated is NarrativeAction.CloseTimeline) {
+                    Timber.d("Auto-executing CloseTimeline (chapter pointer only)")
+                    val closeAction = hydrated
+                    managerScope.launch {
+                        executeNarrativeAction(closeAction, isRetry = isRetry)
+                    }
                 }
 
                 if (narrativeCoordinator.consumePendingReevaluation()) {
@@ -721,9 +756,10 @@ class SagaContentManagerImpl
                 is SagaMilestone.NewEvent -> {
                     getSagaContent()?.currentActInfo?.currentChapterInfo?.let { chapter ->
                         managerScope.launch {
-                            val closeAction = NarrativeAction.CloseTimeline(chapter)
-                            narrativeCoordinator.onBackgroundTaskStarted(BackgroundTask.ClosingScene)
-                            executeNarrativeAction(closeAction, isRetry = false)
+                            chapterUseCase.updateChapter(
+                                chapter.data.copy(currentEventId = null),
+                            )
+                            requestNarrativeProgression()
                         }
                     }
                 }
@@ -742,8 +778,8 @@ class SagaContentManagerImpl
             }
         }
 
-        private fun emitMilestone(milestone: SagaMilestone?) =
-            CoroutineScope(Dispatchers.Main.immediate).launch {
+        private suspend fun emitMilestone(milestone: SagaMilestone?) {
+            withContext(Dispatchers.Main.immediate) {
                 if (milestone != null && milestone.isIntrusive) {
                     isMilestoneActive.value = true
                     narrativeCoordinator.markMilestoneActive()
@@ -754,6 +790,7 @@ class SagaContentManagerImpl
                 }
                 milestoneUpdate.emit(milestone)
             }
+        }
 
         private fun milestoneBackgroundNotification(milestone: SagaMilestone): SagaNotificationEvent? {
             val message =
@@ -935,10 +972,13 @@ class SagaContentManagerImpl
                     } ?: dismissMilestone()
                 }
 
-                is NarrativeAction.CloseTimeline,
-                is NarrativeAction.GenerateEnding,
-                -> {
+                is NarrativeAction.CloseTimeline -> {
                     doNothing()
+                }
+
+                is NarrativeAction.GenerateEnding -> {
+                    contentReasoning.value = null
+                    emitMilestone(null)
                 }
             }
         }
@@ -946,16 +986,57 @@ class SagaContentManagerImpl
         override suspend fun getCurrentObjective(sceneSummary: SceneSummary) {
             val saga = content.value ?: return
             val event = saga.getCurrentTimeLine() ?: return
-            if (event.data.currentObjective.isNullOrEmpty()) {
+            if (!event.data.hasActiveSceneSummary()) {
                 startProcessing {
                     val updatedTimeline =
                         event.data.copy(
+                            sceneSummary = sceneSummary,
                             currentObjective = sceneSummary.immediateObjective,
                         )
                     timelineUseCase.updateTimeline(updatedTimeline)
+                    _sceneSummary.value = sceneSummary
                     showObjective()
                 }
             }
+        }
+
+        /**
+         * Backfills [SceneSummary] when the user returns to a saga whose active timeline never
+         * received an objective (e.g. left during [TimelineUseCase.getTimelineObjective]).
+         */
+        private fun ensureCurrentTimelineSceneSummary(saga: SagaMetadata) {
+            val timeline = saga.getCurrentTimeLine()?.data ?: return
+            if (saga.data.isEnded || !timeline.shouldEnsureSceneSummary()) {
+                timeline.sceneSummary?.let { _sceneSummary.value = it }
+                return
+            }
+            if (isProcessingNarrative.get() || isProcessing.get() || isMilestoneActive.value) {
+                return
+            }
+            objectiveEnsureJob?.cancel()
+            objectiveEnsureJob =
+                managerScope.launch {
+                    try {
+                        setNarrativeProcessingStatus(true)
+                        Timber.i("ensureCurrentTimelineSceneSummary: generating for timeline ${timeline.id}")
+                        timelineUseCase
+                            .getTimelineObjective(saga, timeline)
+                            .onSuccessAsync { updated ->
+                                _sceneSummary.value = updated.sceneSummary
+                                if (
+                                    milestoneUpdate.value == null &&
+                                    !isMilestoneActive.value &&
+                                    updated.hasActiveSceneSummary()
+                                ) {
+                                    emitMilestone(SagaMilestone.CurrentObjective(updated))
+                                }
+                            }.onFailureAsync { e ->
+                                Timber.w(e, "ensureCurrentTimelineSceneSummary failed")
+                            }
+                    } finally {
+                        setNarrativeProcessingStatus(false)
+                    }
+                }
         }
 
         private suspend fun handleChapterPostActions(
@@ -1089,10 +1170,7 @@ class SagaContentManagerImpl
 
         override fun stopProcessing() {
             Timber.i("Stopping all narrative processing")
-            setNarrativeProcessingStatus(false)
-            isProcessing.set(false)
-            narrativeCoordinator.reset()
-            emitMilestone(null)
+            resetSagaSession()
         }
 
         override suspend fun getSagaContent(): SagaContent? = sagaHistoryUseCase.getSagaById(content.value?.data?.id).first()

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -9,6 +9,7 @@ import com.ilustris.sagai.core.ai.services.GenreConfigService
 import com.ilustris.sagai.core.data.RequestResult
 import com.ilustris.sagai.core.data.asSuccess
 import com.ilustris.sagai.core.data.executeRequest
+import com.ilustris.sagai.core.data.isFlowCancellation
 import com.ilustris.sagai.core.file.BackupService
 import com.ilustris.sagai.core.file.ImageHelper
 import com.ilustris.sagai.core.services.RemoteConfigService
@@ -209,6 +210,9 @@ class SagaContentManagerImpl
                     }
                 }
             } catch (e: Exception) {
+                if (e.isFlowCancellation()) {
+                    throw e
+                }
                 Timber.e(e, "Unexpected error executing narrative action")
                 narrativeCoordinator.onActionCompleted(
                     action,
@@ -369,7 +373,7 @@ class SagaContentManagerImpl
                                     _sceneSummary.value = it
                                 }
 
-                                if (sagaImmersiveSession.isSagaActive(saga.data.id)) {
+                                if (sagaImmersiveSession.isOwnerOnTop("chat")) {
                                     sagaThemeManager.updateTheme(saga.data.genre)
                                 }
 
@@ -1123,7 +1127,9 @@ class SagaContentManagerImpl
 
                 is StreamingState.Error -> {
                     contentReasoning.value = null
-                    sagaThemeManager.showSnackBar(state.message)
+                    if (!state.isFlowCancellation()) {
+                        sagaThemeManager.showSnackBar(state.message)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -43,10 +43,9 @@ import com.ilustris.sagai.features.home.data.model.getCurrentTimeLine
 import com.ilustris.sagai.features.home.data.usecase.SagaHistoryUseCase
 import com.ilustris.sagai.features.saga.chat.data.model.Message
 import com.ilustris.sagai.features.saga.chat.data.model.SceneSummary
+import com.ilustris.sagai.features.saga.chat.data.model.SenderType
 import com.ilustris.sagai.features.saga.chat.data.model.hasActiveSceneSummary
 import com.ilustris.sagai.features.saga.chat.data.model.shouldEnsureSceneSummary
-import com.ilustris.sagai.features.saga.chat.data.model.SenderType
-import com.ilustris.sagai.features.saga.chat.domain.manager.BackgroundTask
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeAction
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeActionExecutor
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeActionMaterializer
@@ -55,7 +54,6 @@ import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeCoordinator
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeEvaluationContext
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionEnvironment
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionResult
-import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativePhase
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeUiState
 import com.ilustris.sagai.features.saga.chat.presentation.model.IntroductionType
 import com.ilustris.sagai.features.saga.chat.presentation.model.SagaMilestone
@@ -640,11 +638,10 @@ class SagaContentManagerImpl
                     return@withLock
                 }
 
-                val uiState =
-                    narrativeCoordinator.reevaluate(
-                        nextResolvedAction = hydrated,
-                        context = buildEvaluationContext(),
-                    )
+                narrativeCoordinator.reevaluate(
+                    nextResolvedAction = hydrated,
+                    context = buildEvaluationContext(),
+                )
 
                 if (hydrated is NarrativeAction.CloseTimeline) {
                     Timber.d("Auto-executing CloseTimeline (chapter pointer only)")
@@ -775,24 +772,27 @@ class SagaContentManagerImpl
         private fun milestoneBackgroundNotification(milestone: SagaMilestone): SagaNotificationEvent? {
             val message =
                 when (milestone) {
-                    is SagaMilestone.ChapterFinished ->
+                    is SagaMilestone.ChapterFinished -> {
                         context.getString(
                             R.string.notification_new_chapter_content,
                             milestone.chapter.title,
                         )
+                    }
 
-                    is SagaMilestone.ActFinished ->
+                    is SagaMilestone.ActFinished -> {
                         context.getString(
                             R.string.notification_new_act_content,
                             milestone.act.title,
                             milestone.act.title,
                         )
+                    }
 
-                    is SagaMilestone.NewEvent ->
+                    is SagaMilestone.NewEvent -> {
                         context.getString(
                             R.string.notification_timeline_event_content,
                             milestone.timeline.title,
                         )
+                    }
 
                     is SagaMilestone.NewCharacter -> {
                         val name =
@@ -800,7 +800,9 @@ class SagaContentManagerImpl
                         context.getString(R.string.notification_new_character_content, name)
                     }
 
-                    else -> return null
+                    else -> {
+                        return null
+                    }
                 }
             return notificationEvent(message, NotificationStyle.DEFAULT)
         }
@@ -1149,8 +1151,16 @@ class SagaContentManagerImpl
             }
 
         override fun stopProcessing() {
-            Timber.i("Stopping all narrative processing")
-            resetSagaSession()
+            Timber.i("Stopping active generation without clearing saga session")
+            objectiveEnsureJob?.cancel()
+            objectiveEnsureJob = null
+            contentReasoning.value = null
+            isProcessing.set(false)
+            setNarrativeProcessingStatus(false)
+            narrativeCoordinator.markProcessing(false)
+            if (milestoneUpdate.value is SagaMilestone.Loading) {
+                dismissMilestone()
+            }
         }
 
         override suspend fun getSagaContent(): SagaContent? = sagaHistoryUseCase.getSagaById(content.value?.data?.id).first()

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -245,7 +245,6 @@ class SagaContentManagerImpl
         private fun buildEvaluationContext(): NarrativeEvaluationContext {
             val milestone = milestoneUpdate.value
             return NarrativeEvaluationContext(
-                isOnboardingVisible = isOnboardingVisible.value,
                 isMilestoneActive = isMilestoneActive.value,
                 isNarrativeProcessing = isProcessingNarrative.get(),
                 hasActiveMilestoneOverlay = milestone?.isIntrusive == true,
@@ -618,11 +617,6 @@ class SagaContentManagerImpl
             if (progressionMutex.isLocked) {
                 Timber.i("requestNarrativeProgression: already in progress, queueing reevaluation.")
                 narrativeCoordinator.schedulePendingReevaluation()
-                return
-            }
-
-            if (isOnboardingVisible.value) {
-                Timber.i("requestNarrativeProgression: onboarding visible, skipping.")
                 return
             }
 

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -416,8 +416,6 @@ class SagaContentManagerImpl
                                     checkNarrativeProgression(saga)
                                 }
 
-                                validateCharacters(saga)
-
                                 if (previousSaga == null) {
                                     if (saga.data.isEnded.not()) {
                                         saga.getCurrentTimeLine()?.data?.sceneSummary?.let {
@@ -450,18 +448,6 @@ class SagaContentManagerImpl
                         emitMilestone(null)
                     }
                 }
-        }
-
-        private suspend fun validateCharacters(saga: SagaMetadata) {
-            withContext(Dispatchers.IO) {
-                characterUseCase
-                    .getCharactersBySaga(saga.data.id)
-                    .first()
-                    .filter { it.data.smartZoom == null && it.data.image.isNotEmpty() }
-                    .forEach {
-                        characterUseCase.createSmartZoom(it.data)
-                    }
-            }
         }
 
         private suspend fun checkMessageNotifications(

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/model/SceneSummary.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/model/SceneSummary.kt
@@ -1,5 +1,7 @@
 package com.ilustris.sagai.features.saga.chat.data.model
 
+import com.ilustris.sagai.features.timeline.data.model.Timeline
+
 data class SceneSummary(
     val currentLocation: String,
     val charactersPresent: List<String>,
@@ -16,3 +18,14 @@ data class SceneSummary(
     val possibleOutcomes: List<String>? = emptyList(),
     val quote: String? = null,
 )
+
+/** True when the summary can drive chat objectives and suggestions. */
+fun SceneSummary.isActive(): Boolean =
+    immediateObjective?.isNotBlank() == true || currentLocation.isNotBlank()
+
+fun Timeline.hasActiveSceneSummary(): Boolean =
+    !currentObjective.isNullOrBlank() || (sceneSummary?.isActive() == true)
+
+/** Open timeline that still needs an AI-generated scene summary. */
+fun Timeline.shouldEnsureSceneSummary(): Boolean =
+    id != 0 && !isEmpty() && !hasActiveSceneSummary()

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/usecase/MessageUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/usecase/MessageUseCaseImpl.kt
@@ -234,16 +234,22 @@ class MessageUseCaseImpl
                                         )
                                     }
                                 }
+                                val resolvedSpeaker =
+                                    reply.message.speakerName ?: reply.newCharacter?.name
                                 val savedMessage =
                                     messageRepository.saveMessage(
                                         reply.message.copy(
                                             sagaId = saga.data.id,
                                             timelineId = saga.getCurrentTimeLine()!!.data.id,
+                                            speakerName = resolvedSpeaker,
                                             characterId =
-                                                sagaContent
-                                                    .findCharacter(reply.message.speakerName)
-                                                    ?.data
-                                                    ?.id,
+                                                resolvedSpeaker
+                                                    ?.let { name ->
+                                                        sagaContent
+                                                            .findCharacter(name)
+                                                            ?.data
+                                                            ?.id
+                                                    },
                                             status = MessageStatus.OK,
                                             timestamp = System.currentTimeMillis(),
                                         ),

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
@@ -65,10 +65,11 @@ class NarrativeCoordinator
                     }
 
                     is NarrativeAction.CloseTimeline -> {
+                        // Timeline content is already persisted; closing only clears the chapter pointer.
                         NarrativeUiState(
-                            phase = NarrativePhase.BackgroundProcessing(BackgroundTask.ClosingScene),
+                            phase = NarrativePhase.Playing,
                             pendingAction = null,
-                            backgroundTask = BackgroundTask.ClosingScene,
+                            backgroundTask = null,
                             lastError = null,
                             isProcessing = false,
                         )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
@@ -21,10 +21,6 @@ class NarrativeCoordinator
             nextResolvedAction: NarrativeAction?,
             context: NarrativeEvaluationContext,
         ): NarrativeUiState {
-            if (context.isOnboardingVisible) {
-                return _uiState.value
-            }
-
             if (context.isNarrativeProcessing) {
                 return _uiState.value
             }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeEvaluationContext.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeEvaluationContext.kt
@@ -1,7 +1,6 @@
 package com.ilustris.sagai.features.saga.chat.domain.manager
 
 data class NarrativeEvaluationContext(
-    val isOnboardingVisible: Boolean = false,
     val isMilestoneActive: Boolean = false,
     val isNarrativeProcessing: Boolean = false,
     val hasActiveMilestoneOverlay: Boolean = false,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatStateManager.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatStateManager.kt
@@ -15,6 +15,20 @@ class ChatStateManager {
         _uiState.update(updater)
     }
 
+    /** Drops per-saga UI state while keeping user preferences loaded from settings. */
+    fun resetForNewSaga() {
+        _uiState.update { prev ->
+            ChatUiState(
+                chatState = ChatState.Loading,
+                maxContentLength = prev.maxContentLength,
+                messageEffectsEnabled = prev.messageEffectsEnabled,
+                notificationsEnabled = prev.notificationsEnabled,
+                smartSuggestionsEnabled = prev.smartSuggestionsEnabled,
+                narrativeUiState = NarrativeUiState(),
+            )
+        }
+    }
+
     fun updateLoading(loading: Boolean) {
         _uiState.update { it.copy(isLoading = loading) }
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -676,9 +676,12 @@ class ChatViewModel
                             sagaContent.mainCharacter?.let { updateCharacter(it) }
                         }
 
-                        // Only validate character updates when messages changed
                         if (messagesChanged) {
                             validateCharacterMessageUpdates(sagaContent)
+                        }
+
+                        // Re-check whenever messages change or there is no active scene (e.g. new saga).
+                        if (messagesChanged || sagaContent.getCurrentTimeLine() == null) {
                             sagaContentManager.checkNarrativeProgression(sagaContent)
                         }
 

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -104,7 +104,6 @@ class ChatViewModel
         private var sagaObserverJob: kotlinx.coroutines.Job? = null
         private var milestoneObserverJob: kotlinx.coroutines.Job? = null
         private var preferencesObserverJob: kotlinx.coroutines.Job? = null
-        private var snackBarObserverJob: kotlinx.coroutines.Job? = null
         private var mediaObserverJob: kotlinx.coroutines.Job? = null
         private var processingObserverJob: kotlinx.coroutines.Job? = null
         private var sceneSummaryObserverJob: kotlinx.coroutines.Job? = null
@@ -330,9 +329,6 @@ class ChatViewModel
             preferencesObserverJob?.cancel()
             preferencesObserverJob = observePreferences()
 
-            snackBarObserverJob?.cancel()
-            snackBarObserverJob = observeNotificationUpdates()
-
             mediaObserverJob?.cancel()
             mediaObserverJob = observeMediaState()
 
@@ -425,19 +421,6 @@ class ChatViewModel
             viewModelScope.launch(Dispatchers.IO) {
                 wikiUseCase.getWikisBySaga(sagaId).collectLatest { wikis ->
                     stateManager.updateWikis(wikis)
-                }
-            }
-
-        fun observeNotificationUpdates() =
-            viewModelScope.launch(Dispatchers.IO) {
-                sagaContentManager.notificationUpdate.collect { event ->
-                    val notificationEvent = event ?: return@collect
-                    if (!uiState.value.notificationsEnabled) return@collect
-                    val currentSaga = uiState.value.sagaContent ?: return@collect
-                    notificationManager.sendSnackBarNotification(
-                        saga = currentSaga,
-                        event = notificationEvent,
-                    )
                 }
             }
 

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -2,7 +2,6 @@ package com.ilustris.sagai.features.saga.chat.presentation
 
 import MessageStatus
 import android.content.Context
-import android.content.Intent
 import android.graphics.Bitmap
 import android.net.Uri
 import android.util.LruCache
@@ -18,11 +17,11 @@ import com.ilustris.sagai.core.ai.GuardrailsException
 import com.ilustris.sagai.core.ai.StreamingState
 import com.ilustris.sagai.core.media.MediaPlayerManager
 import com.ilustris.sagai.core.media.MediaPlayerManagerImpl
-import com.ilustris.sagai.core.media.SagaPlaybackService
 import com.ilustris.sagai.core.narrative.NarrativeRules
 import com.ilustris.sagai.core.notifications.ScheduledNotificationService
 import com.ilustris.sagai.core.segmentation.ImageSegmentationHelper
 import com.ilustris.sagai.core.services.RemoteConfigService
+import com.ilustris.sagai.core.theme.SagaImmersiveSession
 import com.ilustris.sagai.core.theme.SagaThemeManager
 import com.ilustris.sagai.core.utils.doNothing
 import com.ilustris.sagai.features.characters.data.usecase.CharacterUseCase
@@ -81,6 +80,7 @@ class ChatViewModel
         private val wikiMapper: WikiMapper,
         private val characterUseCase: CharacterUseCase,
         private val sagaThemeManager: SagaThemeManager,
+        private val sagaImmersiveSession: SagaImmersiveSession,
     ) : ViewModel(),
         DefaultLifecycleObserver {
         private val stateManager = ChatStateManager()
@@ -93,7 +93,6 @@ class ChatViewModel
         private var audioProgressJob: kotlinx.coroutines.Job? = null
         private val audioMediaPlayerManager: MediaPlayerManager = MediaPlayerManagerImpl(context)
         var isForeground = true
-        private val messageDelay = 7.seconds
         private var sendJob: kotlinx.coroutines.Job? = null
 
         private var lastActId: Int = 0
@@ -432,14 +431,13 @@ class ChatViewModel
         fun observeNotificationUpdates() =
             viewModelScope.launch(Dispatchers.IO) {
                 sagaContentManager.notificationUpdate.collect { event ->
-                    event?.let { notificationEvent ->
-                        uiState.value.sagaContent?.let { currentSaga ->
-                            notificationManager.sendSnackBarNotification(
-                                saga = currentSaga,
-                                event = notificationEvent,
-                            )
-                        }
-                    }
+                    val notificationEvent = event ?: return@collect
+                    if (!uiState.value.notificationsEnabled) return@collect
+                    val currentSaga = uiState.value.sagaContent ?: return@collect
+                    notificationManager.sendSnackBarNotification(
+                        saga = currentSaga,
+                        event = notificationEvent,
+                    )
                 }
             }
 
@@ -648,7 +646,9 @@ class ChatViewModel
                             return@collectLatest
                         }
 
-                        sagaThemeManager.updateTheme(sagaContent.data.genre)
+                        if (sagaImmersiveSession.isSagaActive(sagaContent.data.id)) {
+                            sagaThemeManager.updateTheme(sagaContent.data.genre)
+                        }
 
                         val rules =
                             remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: run {
@@ -763,7 +763,15 @@ class ChatViewModel
             }
         }
 
-        // Ambient music controlled by SagaThemeManager and MainActivity
+        // Ambient music: SagaThemeManager + MainActivity (not tied to Activity lifecycle — Nav 3 keeps Chat in backstack)
+
+        fun onChatScreenVisible(sagaId: String) {
+            sagaId.toIntOrNull()?.let { sagaImmersiveSession.push("chat", it) }
+        }
+
+        fun onChatScreenHidden() {
+            sagaImmersiveSession.pop("chat")
+        }
 
         private var startTime: Long = 0L
 
@@ -771,21 +779,10 @@ class ChatViewModel
             super.onResume(owner)
             startTime = System.currentTimeMillis()
             scheduledNotificationService.cancelScheduledNotifications()
-            Timber.tag("ChatViewModel").d("Lifecycle: onResume. Informing service to resume.")
-            context.startService(
-                Intent(context, SagaPlaybackService::class.java).apply {
-                    action = SagaPlaybackService.ACTION_RESUME
-                },
-            )
         }
 
         override fun onStop(owner: LifecycleOwner) {
             super.onStop(owner)
-            context.startService(
-                Intent(context, SagaPlaybackService::class.java).apply {
-                    action = SagaPlaybackService.ACTION_STOP
-                },
-            )
             val saga = uiState.value.sagaContent
             if (saga != null) {
                 viewModelScope.launch(Dispatchers.IO) {
@@ -796,12 +793,6 @@ class ChatViewModel
 
         override fun onPause(owner: LifecycleOwner) {
             super.onPause(owner)
-            Timber.tag("ChatViewModel").d("Lifecycle: onPause called. Informing service to pause.")
-            context.startService(
-                Intent(context, SagaPlaybackService::class.java).apply {
-                    action = SagaPlaybackService.ACTION_PAUSE
-                },
-            )
             isForeground = false
             viewModelScope.launch(Dispatchers.IO) {
                 if (startTime != 0L) {
@@ -820,12 +811,7 @@ class ChatViewModel
 
         override fun onCleared() {
             super.onCleared()
-            Timber.tag("ChatViewModel").d("onCleared called. Killing music service.")
-            context.startService(
-                Intent(context, SagaPlaybackService::class.java).apply {
-                    action = SagaPlaybackService.ACTION_STOP
-                },
-            )
+            sagaImmersiveSession.pop("chat")
             audioMediaPlayerManager.release()
         }
 
@@ -854,15 +840,6 @@ class ChatViewModel
             userConfirmed: Boolean = false,
             isAudio: Boolean = false,
         ) {
-            if (uiState.value.isSendingPending) {
-                sendJob?.cancel()
-                sendJob = null
-                stateManager.updateSendingPending(false)
-                stateManager.updateSendingProgress(0f)
-                stateManager.updateLoading(false)
-                return
-            }
-
             val text = uiState.value.inputValue
             uiState.value.senderType
 
@@ -917,15 +894,12 @@ class ChatViewModel
                             }
 
                             TypoStatus.FIX -> {
-                                delay(5.seconds)
-                                if (uiState.value.typoFixMessage != null) {
-                                    stateManager.updateInput(
-                                        TextFieldValue(
-                                            it.suggestedText ?: uiState.value.inputValue.text,
-                                        ),
-                                    )
-                                    startPendingSend(isAudio)
-                                }
+                                stateManager.updateInput(
+                                    TextFieldValue(
+                                        it.suggestedText ?: uiState.value.inputValue.text,
+                                    ),
+                                )
+                                startPendingSend(isAudio)
                             }
 
                             TypoStatus.ENHANCEMENT -> {
@@ -957,25 +931,9 @@ class ChatViewModel
                     status = MessageStatus.LOADING,
                 )
 
-            sendJob =
-                viewModelScope.launch {
-                    stateManager.updateSendingPending(true)
-                    stateManager.updateLoading(true)
-                    val totalSteps = 10
-                    val delayStep = messageDelay.inWholeMilliseconds / totalSteps
-                    for (i in 1..totalSteps) {
-                        stateManager.updateSendingProgress(i.toFloat() / totalSteps)
-                        delay(delayStep)
-                    }
-                    stateManager.updateSendingPending(false)
-                    stateManager.updateSendingProgress(0f)
-                    val isActuallyAudio = isAudio || uiState.value.isAudioInput
-                    stateManager.updateAudioInput(false)
-                    generationJob =
-                        viewModelScope.launch {
-                            sendMessage(message, true, null, isActuallyAudio)
-                        }
-                }
+            val isActuallyAudio = isAudio || uiState.value.isAudioInput
+            stateManager.updateAudioInput(false)
+            sendMessage(message, true, null, isActuallyAudio)
         }
 
         private fun checkTypo(isAudio: Boolean = false) {
@@ -1007,10 +965,7 @@ class ChatViewModel
                             stateManager.updateInput(
                                 TextFieldValue(it.suggestedText ?: uiState.value.inputValue.text),
                             )
-                            delay(5.seconds)
-                            if (uiState.value.typoFixMessage != null) {
-                                sendInput(userConfirmed = true, isAudio = isAudio)
-                            }
+                            sendInput(userConfirmed = true, isAudio = isAudio)
                         }
                     }
                 }
@@ -1023,7 +978,10 @@ class ChatViewModel
             sceneSummary: SceneSummary?,
             isAudio: Boolean,
         ) {
-            viewModelScope.launch(Dispatchers.IO) {
+            sendJob?.cancel()
+            sendJob =
+                viewModelScope.launch(Dispatchers.IO) {
+                stateManager.updateLoading(true)
                 val saga = uiState.value.sagaContent ?: return@launch
                 val characterReference = saga.findCharacter(message.speakerName)
 
@@ -1056,7 +1014,6 @@ class ChatViewModel
                         resetSuggestions()
                         stateManager.updateInput(TextFieldValue())
 
-                        stateManager.updateLoading(true)
                         viewModelScope.launch(Dispatchers.IO) {
                             val sceneSummaryData =
                                 if (isFromUser) {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -629,7 +629,7 @@ class ChatViewModel
                             return@collectLatest
                         }
 
-                        if (sagaImmersiveSession.isSagaActive(sagaContent.data.id)) {
+                        if (sagaImmersiveSession.isOwnerOnTop("chat")) {
                             sagaThemeManager.updateTheme(sagaContent.data.genre)
                         }
 

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -408,9 +408,45 @@ class ChatViewModel
         private fun observeCharacters(sagaId: Int) =
             viewModelScope.launch(Dispatchers.IO) {
                 characterUseCase.getCharactersBySaga(sagaId).collectLatest { characters ->
-                    stateManager.updateCharacters(characters.map { it.data })
+                    onCharactersRosterUpdated(sagaId, characters.map { it.data })
                 }
             }
+
+        private suspend fun onCharactersRosterUpdated(
+            sagaId: Int,
+            characters: List<com.ilustris.sagai.features.characters.data.model.Character>,
+        ) {
+            stateManager.updateCharacters(characters)
+            syncSelectedCharacterFromRoster(characters)
+
+            val saga = sagaContentManager.content.value?.takeIf { it.data.id == sagaId } ?: return
+            val rules =
+                remoteConfigService.getJson<NarrativeRules>("narrative_rules") ?: return
+            val messages = mapper.mapToActDisplayData(saga, rules)
+            stateManager.updateState {
+                it.copy(
+                    sagaContent = saga,
+                    messages = messages,
+                    characters = saga.characters,
+                )
+            }
+        }
+
+        private fun syncSelectedCharacterFromRoster(
+            characters: List<com.ilustris.sagai.features.characters.data.model.Character>,
+        ) {
+            uiState.value.selectedCharacter?.let { selected ->
+                characters.find { it.id == selected.id }?.takeIf { it != selected }?.let {
+                    stateManager.updateCharacter(it)
+                }
+            }
+            val main = uiState.value.mainCharacter?.data ?: return
+            characters.find { it.id == main.id }?.takeIf { it != main }?.let { updated ->
+                stateManager.updateState { state ->
+                    state.copy(mainCharacter = state.mainCharacter?.copy(data = updated))
+                }
+            }
+        }
 
         private fun observeTopCharacters(sagaId: Int) =
             viewModelScope.launch(Dispatchers.IO) {
@@ -619,6 +655,7 @@ class ChatViewModel
                         if (old == null || new == null) return@distinctUntilChanged old == new
                         old.data.copy(playTimeMs = 0) == new.data.copy(playTimeMs = 0) &&
                             old.acts == new.acts &&
+                            old.characters == new.characters &&
                             old.mainCharacter == new.mainCharacter
                     }.collectLatest { sagaContent ->
 
@@ -1139,7 +1176,9 @@ class ChatViewModel
                                         ),
                                         sceneSummary = sceneSummary,
                                         candidateName = discovery.name,
-                                    ).onFailureAsync {
+                                    ).onSuccessAsync { newCharacter ->
+                                        linkMessageToCharacter(generatedMessage, newCharacter)
+                                    }.onFailureAsync {
                                         sagaThemeManager.showSnackBar(
                                             message = "Ocorreu um erro ao criar o personagem",
                                             action =
@@ -1227,15 +1266,22 @@ class ChatViewModel
                                     )
                                 },
                         )
-                    }.onSuccessAsync {
-                        messageUseCase.updateMessage(
-                            message.copy(
-                                characterId = it.id,
-                                speakerName = it.name,
-                            ),
-                        )
+                    }.onSuccessAsync { newCharacter ->
+                        linkMessageToCharacter(message, newCharacter)
                     }
             }
+        }
+
+        private suspend fun linkMessageToCharacter(
+            message: Message,
+            character: com.ilustris.sagai.features.characters.data.model.Character,
+        ) {
+            messageUseCase.updateMessage(
+                message.copy(
+                    characterId = character.id,
+                    speakerName = character.name,
+                ),
+            )
         }
 
         private fun enableDebugMode(enabled: Boolean) {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -281,6 +281,7 @@ class ChatViewModel
             stateManager.updateGenerating(false)
             stateManager.updateSendingPending(false)
             stateManager.updateSendingProgress(0f)
+            stateManager.updateState { it.copy(reasoningChunk = null) }
         }
 
         private fun observeMileStone() =
@@ -290,7 +291,16 @@ class ChatViewModel
                 }
             }
 
-        private var loadFinished = false
+        private enum class SagaLoadStatus {
+            Idle,
+            Loading,
+            Loaded,
+            NotFound,
+        }
+
+        private var sagaLoadStatus = SagaLoadStatus.Idle
+        private var expectedSagaId: Int? = null
+        private var hasSeenResetNull = false
 
         fun initChat(
             sagaId: String?,
@@ -311,18 +321,24 @@ class ChatViewModel
             generationJob = null
             sendJob?.cancel()
             sendJob = null
-            sagaContentManager.resetSagaSession()
+
+            sagaObserverJob?.cancel()
+            sagaObserverJob = null
+
+            expectedSagaId = sagaId.toInt()
+            sagaLoadStatus = SagaLoadStatus.Loading
+            hasSeenResetNull = false
             notificationManager.clearNotifications()
             lastActId = 0
             lastChapterId = 0
             lastEventId = 0
             lastMessageCount = 0
-            loadFinished = false
             stateManager.resetForNewSaga()
             stateManager.updateLoading(true)
             enableDebugMode(isDebug)
 
-            sagaObserverJob?.cancel()
+            sagaContentManager.resetSagaSession()
+
             sagaObserverJob = observeSaga()
 
             milestoneObserverJob?.cancel()
@@ -661,10 +677,47 @@ class ChatViewModel
 
                         Timber.tag("ChatViewModel").d("observeSaga triggered for genre: ${sagaContent?.data?.genre}")
                         if (sagaContent == null) {
-                            if (loadFinished) {
-                                updateLoading(false)
-                                stateManager.updateState { it.copy(chatState = ChatState.Error("Saga not found.")) }
+                            when (sagaLoadStatus) {
+                                SagaLoadStatus.Loading -> {
+                                    if (!hasSeenResetNull) {
+                                        hasSeenResetNull = true
+                                        return@collectLatest
+                                    }
+                                    sagaLoadStatus = SagaLoadStatus.NotFound
+                                    updateLoading(false)
+                                    stateManager.updateState {
+                                        it.copy(
+                                            chatState =
+                                                ChatState.Error(
+                                                    context.getString(R.string.saga_not_found),
+                                                ),
+                                        )
+                                    }
+                                }
+
+                                SagaLoadStatus.NotFound -> {
+                                    updateLoading(false)
+                                    stateManager.updateState {
+                                        it.copy(
+                                            chatState =
+                                                ChatState.Error(
+                                                    context.getString(R.string.saga_not_found),
+                                                ),
+                                        )
+                                    }
+                                }
+
+                                SagaLoadStatus.Loaded,
+                                SagaLoadStatus.Idle,
+                                -> {
+                                    Unit
+                                }
                             }
+                            return@collectLatest
+                        }
+
+                        val expectedId = expectedSagaId
+                        if (expectedId != null && sagaContent.data.id != expectedId) {
                             return@collectLatest
                         }
 
@@ -692,13 +745,13 @@ class ChatViewModel
                                 isLoading =
                                     when {
                                         sagaContent.data.isEnded -> false
-                                        loadFinished -> it.isLoading
+                                        sagaLoadStatus == SagaLoadStatus.Loaded -> it.isLoading
                                         else -> false
                                     },
                                 isGenerating =
                                     when {
                                         sagaContent.data.isEnded -> false
-                                        loadFinished -> it.isGenerating
+                                        sagaLoadStatus == SagaLoadStatus.Loaded -> it.isGenerating
                                         else -> false
                                     },
                                 activeGenre = sagaContent.data.genre,
@@ -724,7 +777,8 @@ class ChatViewModel
 
                         updateProgress(sagaContent)
 
-                        loadFinished = true
+                        sagaLoadStatus = SagaLoadStatus.Loaded
+                        hasSeenResetNull = false
 
                         if (messagesChanged) {
                             validateMessageStatus(sagaContent)

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -251,7 +251,12 @@ class ChatViewModel
                 is ChatUiAction.AdvanceNarrative -> {
                     generationJob =
                         viewModelScope.launch(Dispatchers.IO) {
-                            sagaContentManager.advanceNarrative()
+                            try {
+                                sagaContentManager.advanceNarrative()
+                            } finally {
+                                stateManager.updateGenerating(false)
+                                updateLoading(false)
+                            }
                         }
                 }
 
@@ -302,22 +307,19 @@ class ChatViewModel
                 Timber.d("initChat: Saga $sagaId already initialized, skipping.")
                 return
             }
-            stateManager.updateLoading(true)
+            generationJob?.cancel()
+            generationJob = null
+            sendJob?.cancel()
+            sendJob = null
+            sagaContentManager.resetSagaSession()
             notificationManager.clearNotifications()
             lastActId = 0
             lastChapterId = 0
             lastEventId = 0
             lastMessageCount = 0
             loadFinished = false
-            stateManager.updateState {
-                it.copy(
-                    chatState = ChatState.Loading,
-                    sagaContent = null,
-                    messages = emptyList(),
-                    characters = emptyList(),
-                )
-            }
-            sagaContentManager.content.value = null
+            stateManager.resetForNewSaga()
+            stateManager.updateLoading(true)
             enableDebugMode(isDebug)
 
             sagaObserverJob?.cancel()
@@ -650,7 +652,18 @@ class ChatViewModel
                                 sagaContent = sagaContent,
                                 messages = messages,
                                 chatState = ChatState.Success,
-                                isLoading = if (loadFinished) it.isLoading else false,
+                                isLoading =
+                                    when {
+                                        sagaContent.data.isEnded -> false
+                                        loadFinished -> it.isLoading
+                                        else -> false
+                                    },
+                                isGenerating =
+                                    when {
+                                        sagaContent.data.isEnded -> false
+                                        loadFinished -> it.isGenerating
+                                        else -> false
+                                    },
                                 activeGenre = sagaContent.data.genre,
                                 flatEvents = sagaContent.flatEvents().map { it.data },
                                 characters = sagaContent.characters,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -1668,7 +1668,7 @@ fun CharactersTopIcons(
     ) {
         itemsIndexed(
             charactersToDisplay,
-            key = { index, character -> "character-$index-${character.id}-${character.name}" },
+            key = { index, character -> "character-$index-${character.id}-${character.image}" },
         ) { index, character ->
             val overlapAmountPx = with(density) { overlapAmount.toPx() }
             with(sharedTransitionScope) {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -126,6 +126,7 @@ import com.ilustris.sagai.features.home.data.model.SagaMetadata
 import com.ilustris.sagai.features.home.data.model.chapterNumber
 import com.ilustris.sagai.features.home.data.model.flatChapters
 import com.ilustris.sagai.features.home.data.model.flatMessages
+import com.ilustris.sagai.features.home.data.model.getCurrentTimeLine
 import com.ilustris.sagai.features.home.data.model.subtitleActAndChapterOrdinals
 import com.ilustris.sagai.features.home.data.model.toInfo
 import com.ilustris.sagai.features.milestone.ui.MilestoneOverlay
@@ -693,6 +694,7 @@ fun ChatContent(
                         )
 
                         val narrativeState = uiState.narrativeUiState
+                        val hasActiveTimeline = content.getCurrentTimeLine() != null
                         val bottomInputState =
                             when {
                                 narrativeState.showAdvanceTrigger &&
@@ -705,8 +707,13 @@ fun ChatContent(
                                     BottomInputState.Background(narrativeState.backgroundTask!!)
                                 }
 
-                                else -> {
+                                hasActiveTimeline &&
+                                    !uiState.selectionState.isSelectionMode -> {
                                     BottomInputState.Chat
+                                }
+
+                                else -> {
+                                    BottomInputState.Unavailable
                                 }
                             }
 
@@ -746,7 +753,8 @@ fun ChatContent(
 
                                 BottomInputState.Chat -> {
                                     AnimatedVisibility(
-                                        uiState.chatState !is ChatState.Loading &&
+                                        hasActiveTimeline &&
+                                            uiState.chatState !is ChatState.Loading &&
                                             saga.isDebug.not() && saga.isEnded.not() &&
                                             !uiState.selectionState.isSelectionMode,
                                         enter = slideInVertically(),
@@ -779,6 +787,8 @@ fun ChatContent(
                                         )
                                     }
                                 }
+
+                                BottomInputState.Unavailable -> Unit
                             }
                         }
 
@@ -1427,18 +1437,6 @@ fun ChatList(
             }
         }
         actList.forEach { act ->
-
-            if (act.isComplete) {
-                item(key = "act-${act.content.data.id}") {
-                    ActComponent(
-                        act.content,
-                        saga.acts.indexOf(act.content) + 1,
-                        saga,
-                        modifier = Modifier,
-                    )
-                }
-            }
-
             act.chapters.forEach { chapter ->
 
                 if (chapter.isComplete) {
@@ -1552,6 +1550,17 @@ fun ChatList(
                 }
             }
 
+            if (act.hasConclusionContent()) {
+                item(key = "act-${act.content.data.id}-conclusion") {
+                    ActComponent(
+                        act.content,
+                        saga.acts.indexOf(act.content) + 1,
+                        saga,
+                        modifier = Modifier,
+                    )
+                }
+            }
+
             if (act.content.data.introduction
                     .isNotEmpty()
             ) {
@@ -1572,28 +1581,30 @@ fun ChatList(
                 }
             }
 
-            item(key = "act-${act.content.data.id}-title") {
-                val title =
-                    act.content.data.title
-                        .ifEmpty {
-                            stringResource(
-                                id = R.string.act_title_template,
-                                saga.actNumber(act.content.data.id).toRoman(),
-                            )
-                        }
-                Text(
-                    title,
-                    style =
-                        MaterialTheme.typography.titleLarge.copy(
-                            brush = genre.gradient(true),
-                            fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
-                            textAlign = TextAlign.Center,
-                        ),
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(16.dp),
-                )
+            if (!act.hasConclusionContent()) {
+                item(key = "act-${act.content.data.id}-title") {
+                    val title =
+                        act.content.data.title
+                            .ifEmpty {
+                                stringResource(
+                                    id = R.string.act_title_template,
+                                    saga.actNumber(act.content.data.id).toRoman(),
+                                )
+                            }
+                    Text(
+                        title,
+                        style =
+                            MaterialTheme.typography.titleLarge.copy(
+                                brush = genre.gradient(true),
+                                fontFamily = MaterialTheme.typography.headlineSmall.fontFamily,
+                                textAlign = TextAlign.Center,
+                            ),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                    )
+                }
             }
         }
         item(key = "saga-${saga.data.id}-header") {
@@ -1612,6 +1623,12 @@ fun ChatList(
     }
 }
 
+/** Act synthesis body shown in chat after its chapters (see [ChatList] item order with [reverseLayout]). */
+private fun ActDisplayData.hasConclusionContent(): Boolean {
+    val data = content.data
+    return data.content.isNotBlank() || !data.emotionalReview.isNullOrBlank()
+}
+
 private sealed interface BottomInputState {
     data object Chat : BottomInputState
 
@@ -1622,6 +1639,9 @@ private sealed interface BottomInputState {
     data class Background(
         val task: BackgroundTask,
     ) : BottomInputState
+
+    /** No active timeline and no narrative advance/background UI — chat input must stay hidden. */
+    data object Unavailable : BottomInputState
 }
 
 @Composable

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -18,7 +18,7 @@ import androidx.compose.animation.SharedTransitionScope
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.EaseIn
-import androidx.compose.animation.core.FastOutLinearInEasing
+import androidx.compose.animation.core.EaseInOutQuad
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -52,8 +52,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -174,9 +172,7 @@ import com.ilustris.sagai.ui.theme.darker
 import com.ilustris.sagai.ui.theme.fadeGradientBottom
 import com.ilustris.sagai.ui.theme.fadedGradientTopAndBottom
 import com.ilustris.sagai.ui.theme.filters.effectForGenre
-import com.ilustris.sagai.ui.theme.genresGradient
 import com.ilustris.sagai.ui.theme.gradient
-import com.ilustris.sagai.ui.theme.gradientAnimation
 import com.ilustris.sagai.ui.theme.gradientFill
 import com.ilustris.sagai.ui.theme.holographicGradient
 import com.ilustris.sagai.ui.theme.levitate
@@ -206,7 +202,6 @@ fun ChatView(
     val activity = LocalActivity.current
     var requiredPermission by remember { mutableStateOf<String?>(null) }
     val requestPermissionLauncher = PermissionService.rememberPermissionLauncher()
-    val content = uiState.sagaContent
     val onAction: (ChatUiAction) -> Unit =
         remember(viewModel) {
             { action ->
@@ -262,169 +257,127 @@ fun ChatView(
             }
         }
 
-        if (content != null) {
-            Box(Modifier.fillMaxSize()) {
-                ModalNavigationDrawer(
-                    drawerState = drawerState,
-                    drawerContent = {
-                        ModalDrawerSheet(
-                            drawerShape = RoundedCornerShape(0.dp),
-                            drawerContainerColor = MaterialTheme.colorScheme.background,
-                        ) {
-                            SagaWikiView(
-                                sagaId = content.data.id.toString(),
-                                onBack = { coroutineScope.launch { drawerState.close() } },
-                                sharedTransitionScope = sharedTransitionScope,
-                                animatedVisibilityScope = animatedVisibilityScope,
-                                interceptSystemBack = drawerState.isOpen,
-                            )
-                        }
-                    },
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    with(sharedTransitionScope) {
-                        Box(modifier = Modifier.fillMaxSize()) {
-                            val chatState = uiState.chatState
-                            uiState.milestone
-
-                            when (chatState) {
-                                is ChatState.Error -> {
-                                    AnimatedVisibility(uiState.isGenerating.not()) {
-                                        EmptyMessagesView(
-                                            text = stringResource(id = R.string.saga_not_found),
-                                            brush =
-                                                gradientAnimation(
-                                                    holographicGradient,
-                                                ),
-                                            modifier = Modifier.align(Alignment.Center),
-                                        )
-                                    }
-                                }
-
-                                is ChatState.Success -> {
-                                    ChatContent(
-                                        uiState = uiState,
-                                        onAction = onAction,
-                                        padding = padding,
-                                        isDebug = isDebug,
-                                        genreVfxPulse = genreVfxPulse,
-                                        sharedTransitionScope = sharedTransitionScope,
-                                        animatedVisibilityScope = animatedVisibilityScope,
-                                    )
-                                }
-
-                                else -> {
-                                    Box(Modifier.fillMaxSize()) {
-                                        SparkIcon(
-                                            brush = gradientAnimation(genresGradient()),
-                                            modifier =
-                                                Modifier
-                                                    .size(50.dp)
-                                                    .align(Alignment.Center),
-                                            duration = 1.seconds,
-                                            blurRadius = 1.dp,
-                                            tint = MaterialTheme.colorScheme.background,
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (showBackupSheet) {
-                BackupSheet(onDismiss = { showBackupSheet = false })
-            }
-
-            if (uiState.showAudioTranscript) {
-                AudioRecordingSheet(
-                    uiState.sagaContent
-                        ?.data
-                        ?.genre
-                        ?.colorPalette() ?: holographicGradient,
-                    onDismiss = {
-                        onAction(ChatUiAction.RequestAudioTranscript(false))
-                    },
-                ) {
-                    onAction(ChatUiAction.UpdateInput(TextFieldValue(it)))
-                    onAction(ChatUiAction.SendInput(userConfirmed = false, isAudio = true))
-                    onAction(ChatUiAction.RequestAudioTranscript(false))
-                }
-            }
-
-            val backupLauncher =
-                PermissionService.rememberBackupLauncher { uri ->
-                    onAction(ChatUiAction.EnableBackup(uri))
-                    requiredPermission = null
-                }
-
-            PermissionComponent(onConfirm = {
-                if (requiredPermission != BACKUP_PERMISSION) {
-                    context?.let {
-                        openAppSettings(context)
-                        requiredPermission = null
-                    }
-                } else {
-                    backupLauncher.launch(null)
-                }
-            }) {
+        val backupLauncher =
+            PermissionService.rememberBackupLauncher { uri ->
+                onAction(ChatUiAction.EnableBackup(uri))
                 requiredPermission = null
             }
 
-            uiState.sagaContent?.let {
-                AnimatedVisibility(
-                    (uiState.isLoading || uiState.isGenerating),
-                    enter = fadeIn(),
-                    exit = fadeOut(),
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    StarryTextPlaceholder(
-                        modifier =
-                            Modifier
-                                .reactiveShimmer(
-                                    true,
-                                    themeShimmer(),
-                                    duration = 2.seconds,
-                                ).fillMaxSize(),
-                    )
+        PermissionComponent(onConfirm = {
+            if (requiredPermission != BACKUP_PERMISSION) {
+                context?.let {
+                    openAppSettings(context)
+                    requiredPermission = null
                 }
+            } else {
+                backupLauncher.launch(null)
+            }
+        }) {
+            requiredPermission = null
+        }
 
-                ShareSheet(
-                    saga = it.data,
-                    isVisible = uiState.showShareSheet,
-                    shareType = ShareType.CONVERSATION,
-                    onDismiss = { onAction(ChatUiAction.ShareConversation(false)) },
-                )
+        when (uiState.chatState) {
+            is ChatState.Loading -> {
+                SagaChatSparkPlaceholder(modifier = Modifier.fillMaxSize())
             }
 
-            content.let {
-                uiState.onboardingType?.let {
-                    OnboardingDialog(
-                        saga = content.data,
-                        type = it,
-                        genre = content.data.genre,
-                        onDismiss = {
-                            viewModel.onOnboardingDismissed()
-                        },
-                    )
-                }
+            is ChatState.Error -> {
+                SagaNotFoundView(modifier = Modifier.fillMaxSize())
             }
-        } else {
-            if (uiState.isGenerating.not() && uiState.isLoading.not()) {
-                Column(
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    modifier = Modifier.fillMaxSize(),
-                ) {
-                    Text(
-                        stringResource(R.string.saga_not_found),
-                    )
 
-                    Button(onClick = {
-                        onBack()
-                    }, colors = ButtonDefaults.textButtonColors()) {
-                        Text(stringResource(R.string.back_button_description))
+            is ChatState.Success -> {
+                val sagaContent = uiState.sagaContent
+                if (sagaContent == null) {
+                    SagaChatSparkPlaceholder(modifier = Modifier.fillMaxSize())
+                } else {
+                    Box(Modifier.fillMaxSize()) {
+                        ModalNavigationDrawer(
+                            drawerState = drawerState,
+                            drawerContent = {
+                                ModalDrawerSheet(
+                                    drawerShape = RoundedCornerShape(0.dp),
+                                    drawerContainerColor = MaterialTheme.colorScheme.background,
+                                ) {
+                                    SagaWikiView(
+                                        sagaId = sagaContent.data.id.toString(),
+                                        onBack = { coroutineScope.launch { drawerState.close() } },
+                                        sharedTransitionScope = sharedTransitionScope,
+                                        animatedVisibilityScope = animatedVisibilityScope,
+                                        interceptSystemBack = drawerState.isOpen,
+                                    )
+                                }
+                            },
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            with(sharedTransitionScope) {
+                                ChatContent(
+                                    uiState = uiState,
+                                    onAction = onAction,
+                                    padding = padding,
+                                    isDebug = isDebug,
+                                    genreVfxPulse = genreVfxPulse,
+                                    sharedTransitionScope = sharedTransitionScope,
+                                    animatedVisibilityScope = animatedVisibilityScope,
+                                )
+                            }
+                        }
+
+                        if (showBackupSheet) {
+                            BackupSheet(onDismiss = { showBackupSheet = false })
+                        }
+
+                        if (uiState.showAudioTranscript) {
+                            AudioRecordingSheet(
+                                sagaContent.data.genre?.colorPalette() ?: holographicGradient,
+                                onDismiss = {
+                                    onAction(ChatUiAction.RequestAudioTranscript(false))
+                                },
+                            ) {
+                                onAction(ChatUiAction.UpdateInput(TextFieldValue(it)))
+                                onAction(
+                                    ChatUiAction.SendInput(
+                                        userConfirmed = false,
+                                        isAudio = true,
+                                    ),
+                                )
+                                onAction(ChatUiAction.RequestAudioTranscript(false))
+                            }
+                        }
+
+                        AnimatedVisibility(
+                            uiState.isLoading || uiState.isGenerating,
+                            enter = fadeIn(),
+                            exit = fadeOut(),
+                            modifier = Modifier.fillMaxSize(),
+                        ) {
+                            StarryTextPlaceholder(
+                                modifier =
+                                    Modifier
+                                        .reactiveShimmer(
+                                            true,
+                                            themeShimmer(),
+                                            duration = 2.seconds,
+                                        ).fillMaxSize(),
+                            )
+                        }
+
+                        ShareSheet(
+                            saga = sagaContent.data,
+                            isVisible = uiState.showShareSheet,
+                            shareType = ShareType.CONVERSATION,
+                            onDismiss = { onAction(ChatUiAction.ShareConversation(false)) },
+                        )
+
+                        uiState.onboardingType?.let { onboardingType ->
+                            OnboardingDialog(
+                                saga = sagaContent.data,
+                                type = onboardingType,
+                                genre = sagaContent.data.genre,
+                                onDismiss = {
+                                    viewModel.onOnboardingDismissed()
+                                },
+                            )
+                        }
                     }
                 }
             }
@@ -469,12 +422,9 @@ fun ChatContent(
             milestoneState,
             modifier = Modifier.fillMaxWidth(),
             transitionSpec = {
-                fadeIn(tween(1000, easing = EaseIn)) togetherWith
+                fadeIn(tween(1000, easing = EaseInOutQuad)) togetherWith
                     fadeOut(
-                        tween(
-                            1500,
-                            easing = FastOutLinearInEasing,
-                        ),
+                        animationSpec = tween(500, easing = EaseInOutQuad),
                     )
             },
         ) {
@@ -522,8 +472,7 @@ fun ChatContent(
                                     shimmerColors = themeShimmer(),
                                     duration = 10.seconds,
                                     targetValue = 1000f,
-                                )
-                                .size(100.dp)
+                                ).size(100.dp)
                                 .alpha(.4f),
                     )
 
@@ -531,8 +480,7 @@ fun ChatContent(
                         Modifier
                             .padding(
                                 top = padding.calculateTopPadding(),
-                            )
-                            .fillMaxSize(),
+                            ).fillMaxSize(),
                     ) {
                         rememberCoroutineScope()
                         val (debugControls, messages, chatInput, topBar, bottomGradient, objectiveOverlay) = createRefs()
@@ -687,8 +635,7 @@ fun ChatContent(
                             Modifier
                                 .constrainAs(bottomGradient) {
                                     bottom.linkTo(parent.bottom)
-                                }
-                                .fillMaxWidth()
+                                }.fillMaxWidth()
                                 .fillMaxHeight(.2f)
                                 .background(fadeGradientBottom(resolvedColor)),
                         )
@@ -788,7 +735,9 @@ fun ChatContent(
                                     }
                                 }
 
-                                BottomInputState.Unavailable -> Unit
+                                BottomInputState.Unavailable -> {
+                                    Unit
+                                }
                             }
                         }
 
@@ -912,19 +861,16 @@ fun ChatContent(
                                                 uiState.isGenerating ||
                                                     uiState.isLoading ||
                                                     genreVfxPulse,
-                                        )
-                                        .size(32.dp)
+                                        ).size(32.dp)
                                         .clip(CircleShape)
                                         .clickable {
                                             onAction(ChatUiAction.ShowObjective)
-                                        }
-                                        .gradientFill(
+                                        }.gradientFill(
                                             progressiveBrush(
                                                 resolvedColor,
                                                 progressState.value,
                                             ),
-                                        )
-                                        .reactiveShimmer(
+                                        ).reactiveShimmer(
                                             uiState.isGenerating || uiState.isLoading,
                                             shimmerColors = themeShimmer(),
                                         ),
@@ -958,8 +904,7 @@ fun ChatContent(
                                             onAction(
                                                 ChatUiAction.OpenSagaDetails,
                                             )
-                                        }
-                                        .fillMaxWidth()
+                                        }.fillMaxWidth()
                                         .padding(start = 8.dp),
                                 titleModifier =
                                     Modifier.graphicsLayer(alpha = alpha),
@@ -1063,8 +1008,7 @@ fun ChatContent(
                                             .background(
                                                 MaterialTheme.colorScheme.surfaceContainer,
                                                 shape,
-                                            )
-                                            .fillMaxWidth(),
+                                            ).fillMaxWidth(),
                                     trailingIcon = {
                                         IconButton(
                                             onClick = {
@@ -1083,8 +1027,7 @@ fun ChatContent(
                                                     .background(
                                                         resolvedColor,
                                                         CircleShape,
-                                                    )
-                                                    .size(32.dp)
+                                                    ).size(32.dp)
                                                     .padding(4.dp),
                                         ) {
                                             Icon(
@@ -1162,6 +1105,46 @@ fun ChatContent(
                 )
             }
         }
+    }
+}
+
+@Composable
+private fun SagaChatSparkPlaceholder(modifier: Modifier = Modifier) {
+    val muted = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_spark),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = muted,
+        )
+    }
+}
+
+@Composable
+private fun SagaNotFoundView(modifier: Modifier = Modifier) {
+    val muted = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.5f)
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_spark),
+            contentDescription = null,
+            modifier = Modifier.size(48.dp),
+            tint = muted,
+        )
+        Text(
+            text = stringResource(R.string.saga_not_found),
+            style = MaterialTheme.typography.bodyLarge,
+            color = muted,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.padding(top = 12.dp),
+        )
     }
 }
 
@@ -1313,8 +1296,7 @@ fun SagaHeader(
                     .fillMaxWidth()
                     .clickable {
                         isDescriptionExpanded = !isDescriptionExpanded
-                    }
-                    .animateContentSize(),
+                    }.animateContentSize(),
         )
     }
 }
@@ -1386,6 +1368,7 @@ fun ChatList(
                         overflow = TextOverflow.Ellipsis,
                         modifier =
                             Modifier
+                                .reactiveShimmer(true)
                                 .levitate()
                                 .padding(16.dp)
                                 .fillMaxWidth()
@@ -1689,11 +1672,9 @@ fun CharactersTopIcons(
                                 } else {
                                     (charactersToDisplay.size - 1 - index).toFloat()
                                 },
-                            )
-                            .graphicsLayer(
+                            ).graphicsLayer(
                                 translationX = if (index > 0) (index * overlapAmountPx) else 0f,
-                            )
-                            .clip(CircleShape)
+                            ).clip(CircleShape)
                             .size(24.dp)
                             .clickable { onCharacterSelected(character) },
                 )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -249,6 +249,11 @@ fun ChatView(
             onBack()
         }
 
+        DisposableEffect(sagaId) {
+            viewModel.onChatScreenVisible(sagaId)
+            onDispose { viewModel.onChatScreenHidden() }
+        }
+
         DisposableEffect(lifecycleOwner, viewModel) {
             lifecycleOwner.lifecycle.addObserver(viewModel)
             onDispose {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -228,7 +228,7 @@ fun ChatView(
             }
         }
 
-        LaunchedEffect(Unit) {
+        LaunchedEffect(sagaId, isDebug) {
             PermissionService.requestPermission(
                 activity,
                 requiredPermission,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -250,7 +250,7 @@ fun ChatView(
         }
 
         DisposableEffect(sagaId) {
-            viewModel.onChatScreenVisible(sagaId)
+            sagaId?.let { viewModel.onChatScreenVisible(it) }
             onDispose { viewModel.onChatScreenHidden() }
         }
 

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatBubble.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatBubble.kt
@@ -271,7 +271,8 @@ fun ChatBubble(
                                     avatarCharacter?.let { character ->
                                         onAction(
                                             MessageAction.ClickCharacter(
-                                                characters.find { it.id == character.id } ?: character,
+                                                characters.find { it.id == character.id }
+                                                    ?: character,
                                             ),
                                         )
                                     }
@@ -293,7 +294,6 @@ fun ChatBubble(
                                         borderSize = 2.dp,
                                         pixelation = 0f,
                                         grainRadius = 0f,
-                                        useFallback = true,
                                         modifier =
                                             Modifier
                                                 .padding(8.dp)
@@ -342,8 +342,7 @@ fun ChatBubble(
                                                     message,
                                                 ),
                                             )
-                                        }
-                                        .size(24.dp)
+                                        }.size(24.dp)
                                         .gradientFill(genre.gradient()),
                                 )
                             }
@@ -363,8 +362,7 @@ fun ChatBubble(
                                         .emotionalEntrance(
                                             message.emotionalTone,
                                             messageEffectsEnabled,
-                                        )
-                                        .wrapContentSize()
+                                        ).wrapContentSize()
                                         .drawWithContent {
                                             drawContent()
                                             val outline =
@@ -378,9 +376,9 @@ fun ChatBubble(
                                                     override fun createShader(size: Size): Shader {
                                                         val shader =
                                                             (
-                                                                sweepGradient(
-                                                                    palette,
-                                                                ) as ShaderBrush
+                                                                    sweepGradient(
+                                                                        palette,
+                                                                    ) as ShaderBrush
                                                                     ).createShader(size)
                                                         val matrix = Matrix()
                                                         matrix.setRotate(
@@ -397,7 +395,8 @@ fun ChatBubble(
                                                 brush = brush,
                                                 style = Stroke(width = 1.dp.toPx()),
                                             )
-                                        }.background(
+                                        }
+                                        .background(
                                             MaterialTheme.colorScheme.surfaceContainer.copy(alpha = .3f),
                                             bubbleShape,
                                         )
@@ -426,11 +425,11 @@ fun ChatBubble(
                                                             )
                                                         }
                                                     },
-                                                ).emotionalEntrance(
+                                                )
+                                                .emotionalEntrance(
                                                     message.emotionalTone,
                                                     messageEffectsEnabled,
-                                                )
-                                                .wrapContentSize()
+                                                ).wrapContentSize()
                                                 .background(
                                                     bubbleStyle.backgroundColor,
                                                     bubbleShape,
@@ -462,7 +461,8 @@ fun ChatBubble(
                                                                 )
                                                             }
                                                         },
-                                                    ).emotionalEntrance(
+                                                    )
+                                                    .emotionalEntrance(
                                                         message.emotionalTone,
                                                         messageEffectsEnabled,
                                                     )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatBubble.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatBubble.kt
@@ -133,6 +133,10 @@ fun ChatBubble(
     isSelected: Boolean = false,
 ) {
     val message = messageContent.message
+    val avatarCharacter =
+        messageContent.character?.let { embedded ->
+            characters.find { it.id == embedded.id } ?: embedded
+        }
     val sender = message.senderType
     val resolvedColor = MaterialTheme.colorScheme.primary
     val resolvedIconColor = MaterialTheme.colorScheme.onPrimary
@@ -258,31 +262,32 @@ fun ChatBubble(
                         horizontalArrangement = Arrangement.spacedBy(4.dp),
                         verticalAlignment = Alignment.Bottom,
                     ) {
-                        val avatarSize = if (messageContent.character == null) 24.dp else 50.dp
+                        val avatarSize = if (avatarCharacter == null) 24.dp else 50.dp
 
                         Box(
                             Modifier
                                 .clip(CircleShape)
                                 .clickable {
-                                    messageContent.character?.let { character ->
+                                    avatarCharacter?.let { character ->
                                         onAction(
                                             MessageAction.ClickCharacter(
-                                                characters.find { it.id == character.id },
+                                                characters.find { it.id == character.id } ?: character,
                                             ),
                                         )
                                     }
                                 }
                                 .size(avatarSize),
                         ) {
-                            messageContent.character?.let { character ->
+                            avatarCharacter?.let { character ->
                                 AnimatedContent(
-                                    character,
+                                    targetState = character.image to character.id,
                                     transitionSpec = {
                                         fadeIn() + scaleIn() togetherWith scaleOut()
                                     },
+                                    label = "ChatBubbleAvatar",
                                 ) {
                                     CharacterAvatar(
-                                        it,
+                                        character,
                                         isLoading = isLoading,
                                         genre = genre,
                                         borderSize = 2.dp,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatInputView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatInputView.kt
@@ -478,15 +478,18 @@ fun ChatInputView(
                     var characterMenu by remember { mutableStateOf(false) }
 
                     AnimatedContent(
-                        actualCharacter,
+                        targetState =
+                            actualCharacter?.let { it.id to it.image }
+                                ?: (content.mainCharacter?.id to content.mainCharacter?.image),
                         modifier =
                             Modifier
                                 .size(32.dp)
                                 .clip(CircleShape)
                                 .clickable { characterMenu = true },
+                        label = "ChatInputAvatar",
                     ) {
                         Box {
-                            val character = it ?: content.mainCharacter
+                            val character = actualCharacter ?: content.mainCharacter
                             character?.let {
                                 CharacterAvatar(
                                     it,
@@ -533,7 +536,13 @@ fun ChatInputView(
                                                     .fillMaxWidth()
                                                     .padding(bottom = 32.dp),
                                         ) {
-                                            items(characters.size) { index ->
+                                            items(
+                                                count = characters.size,
+                                                key = { index ->
+                                                    val c = characters[index]
+                                                    "${c.id}-${c.image}"
+                                                },
+                                            ) { index ->
                                                 val character = characters[index]
                                                 Column(
                                                     horizontalAlignment = Alignment.CenterHorizontally,

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatInputView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/ChatInputView.kt
@@ -447,8 +447,7 @@ fun ChatInputView(
                                                     inputField,
                                                 ),
                                             )
-                                        }
-                                        .padding(8.dp),
+                                        }.padding(8.dp),
                             )
                         }
                     }
@@ -462,8 +461,7 @@ fun ChatInputView(
                     .background(
                         MaterialTheme.colorScheme.surfaceContainer.copy(alpha = .5f),
                         inputShape,
-                    )
-                    .fillMaxWidth()
+                    ).fillMaxWidth()
                     .heightIn(max = 400.dp)
                     .padding(8.dp),
             ) {
@@ -496,7 +494,7 @@ fun ChatInputView(
                                     genre = genre,
                                     grainRadius = 0f,
                                     pixelation = 0f,
-                                    useFallback = true,
+                                    useFallback = false,
                                     modifier = Modifier.fillMaxSize(),
                                     borderSize = 1.dp,
                                     innerPadding = 0.dp,
@@ -552,8 +550,7 @@ fun ChatInputView(
                                                             .clickable {
                                                                 onSelectCharacter(character)
                                                                 characterMenu = false
-                                                            }
-                                                            .padding(8.dp),
+                                                            }.padding(8.dp),
                                                 ) {
                                                     CharacterAvatar(
                                                         character,
@@ -1146,8 +1143,7 @@ fun ChatInputView(
                                                                         1.dp,
                                                                         col.copy(alpha = .3f),
                                                                         CircleShape,
-                                                                    )
-                                                                    .background(
+                                                                    ).background(
                                                                         col.copy(alpha = .1f),
                                                                         CircleShape,
                                                                     )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/milestone/LoadingMilestoneOverlay.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/milestone/LoadingMilestoneOverlay.kt
@@ -1,7 +1,12 @@
 package com.ilustris.sagai.features.saga.chat.ui.components.milestone
 
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.EaseInOutQuad
 import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -65,7 +70,8 @@ fun LoadingMilestoneOverlay(
                         .gradientFill(Brush.verticalGradient(genre.colorPalette()))
                         .size(
                             50.dp,
-                        ).reactiveShimmer(
+                        )
+                        .reactiveShimmer(
                             true,
                             duration = 4.seconds,
                             targetValue = 200f,
@@ -73,22 +79,27 @@ fun LoadingMilestoneOverlay(
                         ),
             )
 
-            AnimatedContent(contentReasoning) { text ->
+            AnimatedContent(contentReasoning, transitionSpec = {
+                fadeIn(tween(1000, easing = EaseInOutQuad)) togetherWith
+                    fadeOut(
+                        animationSpec = tween(500, easing = EaseInOutQuad),
+                    )
+            }) { text ->
                 text?.let {
                     Text(
                         it,
                         style =
-                            MaterialTheme.typography.bodyLarge.copy(
-                                fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                            MaterialTheme.typography.labelMedium.copy(
                                 textAlign = TextAlign.Center,
                                 shadow =
                                     Shadow(
                                         MaterialTheme.colorScheme.primary,
-                                        blurRadius = 5f,
+                                        blurRadius = 10f,
                                     ),
                             ),
                         modifier =
                             Modifier
+                                .reactiveShimmer(true)
                                 .padding(16.dp)
                                 .fillMaxWidth(),
                     )

--- a/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
@@ -57,6 +57,9 @@ class SagaDetailViewModel
         private var cachedIconPath: String? = null
         private var initialSectionJob: kotlinx.coroutines.Job? = null
 
+        /** One entry SFX per detail visit — cleared when the screen is hidden. */
+        private var pendingEntryVfxSagaId: Int? = null
+
         fun togglePremiumSheet() {
             showPremiumSheet.value = !showPremiumSheet.value
         }
@@ -120,8 +123,15 @@ class SagaDetailViewModel
                     sagaDetailUseCase.getSagaResume(sagaId).collectLatest { resume ->
                         resume.let { data ->
                             this@SagaDetailViewModel.sagaResume.value = data
-                            if (sagaImmersiveSession.isSagaActive(sagaId)) {
-                                sagaThemeManager.updateTheme(data.saga.genre, playEntryVfx = true)
+                            if (sagaImmersiveSession.isOwnerOnTop("saga_detail")) {
+                                val playEntryVfx = pendingEntryVfxSagaId == sagaId
+                                sagaThemeManager.updateTheme(
+                                    data.saga.genre,
+                                    playEntryVfx = playEntryVfx,
+                                )
+                                if (playEntryVfx) {
+                                    pendingEntryVfxSagaId = null
+                                }
                             }
 
                             loadInitialSection()
@@ -177,10 +187,12 @@ class SagaDetailViewModel
 
         fun onDetailScreenVisible(sagaId: Int) {
             sagaImmersiveSession.push("saga_detail", sagaId)
+            pendingEntryVfxSagaId = sagaId
         }
 
         fun onDetailScreenHidden() {
             sagaImmersiveSession.pop("saga_detail")
+            pendingEntryVfxSagaId = null
         }
 
         private fun launchIntroSequence() {
@@ -191,6 +203,7 @@ class SagaDetailViewModel
         }
 
         override fun onCleared() {
+            pendingEntryVfxSagaId = null
             super.onCleared()
             sagaImmersiveSession.pop("saga_detail")
         }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/detail/presentation/SagaDetailViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilustris.sagai.core.ai.StreamingState
 import com.ilustris.sagai.core.data.State
+import com.ilustris.sagai.core.theme.SagaImmersiveSession
 import com.ilustris.sagai.core.theme.SagaThemeManager
 import com.ilustris.sagai.core.utils.doNothing
 import com.ilustris.sagai.core.utils.emptyString
@@ -34,6 +35,7 @@ class SagaDetailViewModel
         private val sagaDetailUseCase: SagaDetailUseCase,
         private val sagaDetailUIMapper: SagaDetailUIMapper,
         private val sagaThemeManager: SagaThemeManager,
+        private val sagaImmersiveSession: SagaImmersiveSession,
     ) : ViewModel() {
         private val _state = MutableStateFlow<State>(State.Success(Unit))
         val state: StateFlow<State> = _state.asStateFlow()
@@ -118,7 +120,9 @@ class SagaDetailViewModel
                     sagaDetailUseCase.getSagaResume(sagaId).collectLatest { resume ->
                         resume.let { data ->
                             this@SagaDetailViewModel.sagaResume.value = data
-                            sagaThemeManager.updateTheme(data.saga.genre, playEntryVfx = true)
+                            if (sagaImmersiveSession.isSagaActive(sagaId)) {
+                                sagaThemeManager.updateTheme(data.saga.genre, playEntryVfx = true)
+                            }
 
                             loadInitialSection()
                             detailDrawer.value =
@@ -171,10 +175,23 @@ class SagaDetailViewModel
             }
         }
 
+        fun onDetailScreenVisible(sagaId: Int) {
+            sagaImmersiveSession.push("saga_detail", sagaId)
+        }
+
+        fun onDetailScreenHidden() {
+            sagaImmersiveSession.pop("saga_detail")
+        }
+
         private fun launchIntroSequence() {
             viewModelScope.launch {
                 delay(2.seconds)
                 showIntro.value = false
             }
+        }
+
+        override fun onCleared() {
+            super.onCleared()
+            sagaImmersiveSession.pop("saga_detail")
         }
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/detail/ui/SagaDetailView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/detail/ui/SagaDetailView.kt
@@ -120,9 +120,11 @@ fun SagaDetailView(
     SagAITheme(genre = resume?.saga?.genre) {
         var lastNavigationTime by remember { mutableStateOf(0L) }
         val onAction: (DetailAction) -> Unit =
-            remember(onCharacterDetails, onLoreDebug, viewModel) {
+            remember(onBack, onCharacterDetails, onLoreDebug, viewModel) {
                 { action ->
                     when (action) {
+                        DetailAction.Back -> onBack()
+
                         DetailAction.OpenReview -> {
                             showReview = true
                         }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/detail/ui/SagaDetailView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/detail/ui/SagaDetailView.kt
@@ -35,6 +35,7 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -269,7 +270,15 @@ fun SagaDetailView(
         }
     }
 
-    LaunchedEffect(Unit) {
+    DisposableEffect(sagaId) {
+        val id = sagaId.toIntOrNull() ?: 0
+        if (id != 0) {
+            viewModel.onDetailScreenVisible(id)
+        }
+        onDispose { viewModel.onDetailScreenHidden() }
+    }
+
+    LaunchedEffect(sagaId) {
         viewModel.fetchSagaDetails(sagaId.toInt())
     }
 }

--- a/app/src/main/java/com/ilustris/sagai/features/timeline/domain/TimelineUseCaseImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/timeline/domain/TimelineUseCaseImpl.kt
@@ -29,6 +29,7 @@ import com.ilustris.sagai.features.timeline.data.repository.TimelineRepository
 import com.ilustris.sagai.features.wiki.data.model.Wiki
 import com.ilustris.sagai.features.wiki.data.usecase.EmotionalUseCase
 import com.ilustris.sagai.features.wiki.data.usecase.WikiUseCase
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -236,6 +237,9 @@ class TimelineUseCaseImpl
                         }
                     }
             } catch (e: Exception) {
+                if (e is CancellationException) {
+                    throw e
+                }
                 emit(
                     StreamingState
                         .Error(e.message ?: "Unknown error"),
@@ -309,6 +313,9 @@ class TimelineUseCaseImpl
                         }
                     }
             } catch (e: Exception) {
+                if (e is CancellationException) {
+                    throw e
+                }
                 emit(
                     StreamingState
                         .Error(e.message ?: "Unknown error"),

--- a/app/src/main/java/com/ilustris/sagai/ui/animations/ThinkingText.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/animations/ThinkingText.kt
@@ -102,7 +102,7 @@ fun ThinkingText(
                                 textAlpha = 1f
                                 onRevealed()
                             },
-                    starColor = MaterialTheme.colorScheme.secondary,
+                    starColor = MaterialTheme.colorScheme.onPrimary.copy(alpha = starAlpha),
                     starCount = text.length,
                 )
             }

--- a/app/src/main/java/com/ilustris/sagai/ui/components/BookGenerationReasoning.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/BookGenerationReasoning.kt
@@ -1,0 +1,53 @@
+package com.ilustris.sagai.ui.components
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.ilustris.sagai.core.ai.model.GenreVisualConfig
+import com.ilustris.sagai.features.newsaga.data.model.Genre
+import com.ilustris.sagai.features.newsaga.data.model.shimmerColors
+import com.ilustris.sagai.ui.theme.reactiveShimmer
+
+@Composable
+fun BookGenerationReasoning(
+    reasoning: String?,
+    genre: Genre,
+    visualConfig: GenreVisualConfig,
+    modifier: Modifier = Modifier,
+) {
+    AnimatedContent(
+        targetState = reasoning,
+        label = "BookGenerationReasoning",
+        transitionSpec = {
+            fadeIn(tween(300)) togetherWith fadeOut(tween(200))
+        },
+        modifier = modifier.fillMaxWidth(),
+    ) { text ->
+        if (text != null) {
+            Text(
+                text = text,
+                style =
+                    MaterialTheme.typography.bodyMedium.copy(
+                        fontFamily = MaterialTheme.typography.bodyLarge.fontFamily,
+                        lineHeight = 22.sp,
+                        color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.85f),
+                        textAlign = TextAlign.Center,
+                    ),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .reactiveShimmer(true, genre.shimmerColors(visualConfig)),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/ilustris/sagai/ui/components/GenreMemoriesLoader.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/GenreMemoriesLoader.kt
@@ -9,8 +9,10 @@ import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -41,10 +43,12 @@ import kotlinx.coroutines.delay
 fun GenreMemoriesLoader(
     genresConfigs: List<Pair<Genre, GenreVisualConfig?>>,
     isLoading: Boolean,
-    message: String,
+    reasoning: String?,
     modifier: Modifier = Modifier,
 ) {
     var configs by remember { mutableStateOf(genresConfigs.shuffled()) }
+    val displayGenre = genresConfigs.firstOrNull()?.first ?: Genre.FANTASY
+    val displayConfig = genresConfigs.firstOrNull()?.second ?: GenreVisualConfig()
 
     LaunchedEffect(Unit) {
         while (true) {
@@ -53,31 +57,49 @@ fun GenreMemoriesLoader(
         }
     }
 
-    Box(
+    Column(
         modifier =
             modifier
-                .fillMaxSize(),
-        contentAlignment = Alignment.Center,
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
+        Box(
             modifier =
                 Modifier
-                    .align(Alignment.Center)
-                    .fillMaxSize()
-                    .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            userScrollEnabled = false,
+                    .weight(1f)
+                    .fillMaxWidth(),
+            contentAlignment = Alignment.Center,
         ) {
-            items(configs, key = { it }) { genre ->
-                GenreMemoryItem(
-                    genreConfig = genre,
-                    modifier = Modifier
-                        .padding(4.dp)
-                        .animateItem(),
-                )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                userScrollEnabled = false,
+            ) {
+                items(configs, key = { it }) { genre ->
+                    GenreMemoryItem(
+                        genreConfig = genre,
+                        modifier =
+                            Modifier
+                                .padding(4.dp)
+                                .animateItem(),
+                    )
+                }
             }
+        }
+
+        if (isLoading) {
+            BookGenerationReasoning(
+                reasoning = reasoning,
+                genre = displayGenre,
+                visualConfig = displayConfig,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 24.dp, top = 8.dp),
+            )
         }
     }
 }

--- a/app/src/main/java/com/ilustris/sagai/ui/components/NewSagaBookFocus.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/NewSagaBookFocus.kt
@@ -1,0 +1,78 @@
+@file:OptIn(ExperimentalSharedTransitionApi::class)
+
+package com.ilustris.sagai.ui.components
+
+import androidx.compose.animation.AnimatedVisibilityScope
+import androidx.compose.animation.ExperimentalSharedTransitionApi
+import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ilustris.sagai.core.ai.model.GenreVisualConfig
+import com.ilustris.sagai.features.newsaga.data.usecase.SagaBook
+import com.ilustris.sagai.features.newsaga.ui.presentation.AgenticAction
+import com.ilustris.sagai.ui.animations.chromaticAberration
+import com.ilustris.sagai.ui.animations.divineAura
+import com.ilustris.sagai.ui.theme.levitate
+
+@Composable
+fun SharedTransitionScope.NewSagaBookFocus(
+    book: SagaBook,
+    visualConfig: GenreVisualConfig,
+    reasoning: String?,
+    isOpened: Boolean,
+    isLoading: Boolean,
+    animatedVisibilityScope: AnimatedVisibilityScope,
+    sharedContentKey: String,
+    lockedCharacter: com.ilustris.sagai.features.characters.data.model.CharacterInfo? = null,
+    onToggle: () -> Unit = {},
+    onAction: (AgenticAction) -> Unit = {},
+    modifier: Modifier = Modifier,
+) {
+    val genre = book.draft.genre
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        CosmicBook(
+            book = book,
+            visualConfig = visualConfig,
+            isOpened = isOpened,
+            lockedCharacter = lockedCharacter,
+            isLoading = isLoading,
+            reasoning = null,
+            onToggle = onToggle,
+            onAction = onAction,
+            modifier =
+                Modifier
+                    .sharedBounds(
+                        rememberSharedContentState(key = sharedContentKey),
+                        animatedVisibilityScope,
+                    )
+                    .width(280.dp)
+                    .fillMaxHeight(0.5f)
+                    .levitate(true)
+                    .divineAura()
+                    .chromaticAberration(),
+        )
+
+        BookGenerationReasoning(
+            reasoning = reasoning,
+            genre = genre,
+            visualConfig = visualConfig,
+            modifier = Modifier.padding(top = 20.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/ilustris/sagai/ui/components/SagaInAppNotificationBanner.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/SagaInAppNotificationBanner.kt
@@ -1,0 +1,158 @@
+package com.ilustris.sagai.ui.components
+
+import android.graphics.Bitmap
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.dropShadow
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.shadow.Shadow
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.DpOffset
+import androidx.compose.ui.unit.dp
+import com.ilustris.sagai.R
+import com.ilustris.sagai.core.notifications.SagaInAppNotification
+import com.ilustris.sagai.features.newsaga.data.model.Genre
+import com.ilustris.sagai.features.newsaga.data.model.resolveBackground
+import com.ilustris.sagai.ui.theme.darker
+import com.ilustris.sagai.ui.theme.gradient
+import com.ilustris.sagai.ui.theme.holographicGradient
+import com.ilustris.sagai.ui.theme.sagaShape
+
+@Composable
+fun SagaInAppNotificationBanner(
+    notification: SagaInAppNotification?,
+    onOpen: (deepLink: String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val genre = notification?.genre
+    val mainColor = MaterialTheme.colorScheme.surface
+    val contentColor = genre?.iconColor ?: MaterialTheme.colorScheme.onSurface
+    val shape = sagaShape() ?: MaterialTheme.shapes.medium
+    val borderBrush = genre?.gradient() ?: Brush.verticalGradient(holographicGradient)
+
+    AnimatedVisibility(
+        visible = notification != null,
+        modifier = modifier,
+        enter = slideInVertically { -it } + fadeIn(tween(400)),
+        exit = slideOutVertically { -it },
+    ) {
+        notification?.let { item ->
+            Row(
+                Modifier
+                    .dropShadow(
+                        shape = shape,
+                        shadow =
+                            Shadow(
+                                radius = 12.dp,
+                                spread = 1.dp,
+                                color = mainColor.darker(),
+                                offset = DpOffset(0.dp, 4.dp),
+                            ),
+                    )
+                    .clip(shape)
+                    .border(1.dp, borderBrush, shape)
+                    .background(mainColor, shape)
+                    .fillMaxWidth()
+                    .clickable { onOpen(item.deepLink) }
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                NotificationAvatar(item.icon, genre)
+
+                Column(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(2.dp),
+                ) {
+                    Text(
+                        item.sagaTitle,
+                        style =
+                            MaterialTheme.typography.labelLarge.copy(
+                                fontWeight = FontWeight.SemiBold,
+                                color = contentColor,
+                            ),
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        item.message,
+                        style =
+                            MaterialTheme.typography.bodySmall.copy(
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            ),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+
+                Text(
+                    stringResource(R.string.notification_open_chat),
+                    style =
+                        MaterialTheme.typography.labelMedium.copy(
+                            color = contentColor,
+                            fontWeight = FontWeight.Bold,
+                        ),
+                    modifier =
+                        Modifier
+                            .clip(shape)
+                            .clickable { onOpen(item.deepLink) }
+                            .padding(horizontal = 4.dp, vertical = 2.dp),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun NotificationAvatar(
+    icon: Bitmap?,
+    genre: Genre?,
+) {
+    val fallbackRes = genre?.resolveBackground(null) as? Int ?: R.drawable.ic_spark
+    if (icon != null) {
+        Image(
+            bitmap = icon.asImageBitmap(),
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .size(40.dp)
+                    .clip(CircleShape),
+        )
+    } else {
+        Image(
+            painter = painterResource(fallbackRes),
+            contentDescription = null,
+            modifier =
+                Modifier
+                    .size(40.dp)
+                    .clip(CircleShape)
+                    .background(MaterialTheme.colorScheme.surfaceVariant, CircleShape)
+                    .padding(8.dp),
+        )
+    }
+}

--- a/app/src/main/java/com/ilustris/sagai/ui/components/SagaSnackBar.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/SagaSnackBar.kt
@@ -39,8 +39,11 @@ data class SagaSnackBarMessage(
     val action: Pair<String, () -> Unit>? = null,
 )
 
-/** Background notification payload (not shown in the global toast UI). */
+/** Saga activity payload routed to in-app banner or system notification. */
 data class SagaNotificationEvent(
+    val sagaId: Int,
+    val sagaTitle: String,
+    val genre: Genre,
     val message: String,
     val icon: Bitmap? = null,
     val largeIcon: Bitmap? = null,

--- a/app/src/main/java/com/ilustris/sagai/ui/navigation/SagaEntryProvider.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/navigation/SagaEntryProvider.kt
@@ -36,6 +36,7 @@ fun createSagaEntryProvider(
             navToSaga = { sagaId, isDebug -> navigator.navigate(ChatKey(sagaId, isDebug)) },
             navToFAQ = { navigator.navigate(FAQKey) },
             navToAuditLogs = { navigator.navigate(AuditLogsKey) },
+            navToPlaythrough = { navigator.navigate(PlaythroughKey) },
             padding = padding,
             sharedTransitionScope = sharedTransitionScope,
             animatedVisibilityScope = LocalNavAnimatedContentScope.current,

--- a/app/src/main/java/com/ilustris/sagai/ui/theme/filters/Filters.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/theme/filters/Filters.kt
@@ -280,7 +280,9 @@ fun Modifier.fallbackEffect(
             )
     }
     if (softFocusRadius > 0f) {
-        modifier = modifier.blur((softFocusRadius * fallbackReduction).dp)
+        // Cap blur so small targets (avatars) are not reduced to a flat color blob.
+        val blurDp = (softFocusRadius * fallbackReduction).coerceAtMost(4f)
+        modifier = modifier.blur(blurDp.dp)
     }
     return modifier
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -205,6 +205,7 @@
     <string name="notification_explanation">To notify you about new messages in your saga when you\'re not in the app, please allow notification permission.</string>
     <string name="continue_text">continue</string>
     <string name="notification_title">New message on %s</string>
+    <string name="notification_open_chat">Open</string>
     <string name="notification_playing_act">Playing Volume %s</string>
     <string name="notification_action_pause" translatable="false">Pause</string>
     <string name="notification_action_play" translatable="false">Play</string>

--- a/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
+++ b/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
@@ -23,19 +23,6 @@ class NarrativeCoordinatorTest {
     }
 
     @Test
-    fun `reevaluate skips when onboarding visible`() {
-        coordinator.reevaluate(NarrativeAction.CreateAct, NarrativeEvaluationContext())
-        val initial = coordinator.uiState.value
-
-        coordinator.reevaluate(
-            NarrativeAction.CreateAct,
-            NarrativeEvaluationContext(isOnboardingVisible = true),
-        )
-
-        assertEquals(initial, coordinator.uiState.value)
-    }
-
-    @Test
     fun `failure restores awaiting advance for user actions`() {
         val act = ActContent(data = Act(id = 1, sagaId = 1))
         val action = NarrativeAction.GenerateActIntro(act)

--- a/docs/release_notes/release_1.10.3.md
+++ b/docs/release_notes/release_1.10.3.md
@@ -1,0 +1,93 @@
+✦ Sagas 1.10.3 — Google Play (≤500 chars per language)
+
+Copy the block below into Play Console → Release → Release notes.
+
+---
+
+🇺🇸 English (498 chars)
+
+```
+Your long messages finally reach the AI—no more silent truncation at 500 characters.
+
+Stay in the story: in-app banners and notifications when your saga moves, even off the chat screen.
+
+Faster sends, synced character portraits, smoother new-saga creation, and ambient music that survives a trip to the background.
+
+Stopping generation won't ghost your saga. Chat loading is clearer. Update and keep writing.
+```
+
+---
+
+🇧🇷 Português (499 chars)
+
+```
+Mensagens longas chegam inteiras na IA—sem cortar em 500 caracteres no escuro.
+
+Fique no loop: banner no app e notificações quando a saga avança, mesmo fora do chat.
+
+Envio mais rápido, avatares sincronizados, criação de saga mais fluida e trilha que aguenta ir pro background.
+
+Parar a geração não apaga sua saga. Carregamento do chat mais claro. Atualiza e continua escrevendo.
+```
+
+---
+
+✦ Full notes (archive / Firebase — not for Play)
+
+🇺🇸 English
+
+✍️ **Your words, all of them**
+
+Messages and chat history were clipped before they reached the AI—awkward when the app lets you type up to 2000 characters. Long replies now stay intact in prompts.
+
+🔔 **Never miss a plot twist**
+
+Hybrid notifications: WhatsApp-style in-app banner when you're elsewhere in the app, system alerts when Sagas is in the background. Milestones on new chapters, acts, and timelines.
+
+⚡ **Chat that keeps up**
+
+Instant send (no artificial delay), immersive theme owned by the screen you're on, and CHAT notifications that respect your settings.
+
+🎭 **Faces in the crowd**
+
+Character avatars refresh when the roster changes; new NPCs link to their first AI appearance. Cleaner portraits without heavy smart-zoom on tiny icons.
+
+📖 **New saga, new polish**
+
+Chronicle-style book focus and live reasoning while your world generates. Ambient music resumes safely after backgrounding—no crash surprises.
+
+🛑 **Stop without panic**
+
+Cancel generation without wiping the current saga. Clearer loading vs "saga not found" when switching stories.
+
+That's 1.10.3—polish, presence, and fewer "what just happened?" moments.
+
+---
+
+🇧🇷 Português
+
+✍️ **Suas palavras, inteiras**
+
+Mensagens e histórico eram cortados antes da IA—estranho com limite de 2000 no app. Respostas longas agora vão completas pro modelo.
+
+🔔 **Não perca o próximo capítulo**
+
+Notificações híbridas: banner no app estilo WhatsApp quando você está em outra tela, alerta no sistema com o app em background. Marcos em capítulos, atos e eventos.
+
+⚡ **Chat no ritmo certo**
+
+Envio instantâneo, tema imersivo só na tela ativa, e notificações de chat que respeitam suas preferências.
+
+🎭 **Rostos certos na conversa**
+
+Avatares atualizam quando o elenco muda; personagens novos ligam à primeira fala da IA. Retratos mais limpos sem smart zoom pesado em ícones pequenos.
+
+📖 **Nova saga com mais cara**
+
+Foco no livro e raciocínio ao vivo na criação. Trilha ambiente volta com segurança depois do background—sem susto de crash.
+
+🛑 **Parar sem apagar tudo**
+
+Cancelar geração sem perder a saga atual. Carregamento mais claro vs "saga não encontrada" ao trocar de história.
+
+É a 1.10.3—presença, polimento e menos "o que aconteceu?".

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 # Version components following MAJOR.MINOR.PATCH convention
 MAJOR=1
 MINOR=10
-PATCH=2
+PATCH=3


### PR DESCRIPTION
## Summary
- `toAINormalize()` was truncating every `String` field at 500 characters
- Chat messages and conversation history use field `text` and are sent via `toAINormalize` in `ChatPrompts.replyMessagePrompt` / `conversationHistory`
- UI allows up to 2000 chars (`chat_input_limit`); only the AI prompt was clipped
- Message `text` now keeps up to 8192 chars; other descriptive fields stay at 500

## Test plan
- [ ] Send a message with 600+ characters — AI reply should reference full content
- [ ] Verify long messages in chat history still reach the model on follow-up turns
- [ ] Confirm backstory/summary fields still truncate at 500 where expected


Made with [Cursor](https://cursor.com)