### PR TITLE
feat: auto-chain narrative setup (1.10.4)

### DIFF
--- a/.agent/workflows/create_release_notes.md
+++ b/.agent/workflows/create_release_notes.md
@@ -2,46 +2,20 @@
 description: Create release notes for Google Play Store
 ---
 
-This workflow guides you through creating release notes for the Google Play Store, maintaining the
-app's friendly and engaging voice.
+**Use the project skill:** `.cursor/skills/google-play-release-notes/SKILL.md` (tone: enxuto, sarcasmo, petulância — sem detalhe técnico).
 
-1. **Smart Commit Check**:
-    - Run the `.agent/workflows/smart_commit.md` workflow to ensure all changes are committed and
-      summarized.
+1. **Context**
+   - `version.properties` → versão
+   - `git log -n 15 --oneline` na branch de release (ou diff vs `main`)
+   - Um tema por release, não lista de commits
 
-2. **Gather Context from Git**:
-    - **Analyze Commits**: Run `git log -n 15 --oneline develop` to see the latest ~15 commits on
-      the develop branch.
-    - **Analyze Merges**: Run `git log --merges -n 2 --oneline develop` to see the latest 2 merges.
-    - **Identify Changes**: Extract a list of **New Features** and **Bug Fixes** from these logs.
-    - **Version**: Read `version.properties` to construct the version number (format:
-      `MAJOR.MINOR.PATCH`).
-    - **Theme**: Infer a "theme" for the update if possible, or ask the user.
+2. **Write**
+   - `docs/release_notes/release_[version].md`
+   - Só blocos 🇺🇸 English e 🇧🇷 Português (2–4 frases cada; ~500 chars se for colar na Play)
+   - `git add -f docs/release_notes/release_[version].md`
 
-2. **Drafting the Release Notes**:
-    - Create a new markdown file (e.g., `docs/release_notes/release_[version].md`).
-   - **Tone**: Exciting, concise, and slightly humorous. Use a "catchy" voice that feels like a
-     friend sharing cool news. Don't be afraid of a random joke or pun if it fits.
-    - **Structure**:
-        - **Title**: "✦ What's New in Sagas [Version] ✨"
-        - **English Version 🇺🇸**:
-            - **Intro**: A quick, punchy sentence about the update. Feel free to add a small joke or
-              witty remark here.
-            - **Feature List**: Bullet points with emojis. Focus on the *benefit* to the user, not
-              just the technical change.
-                - *Bad*: "Added new Auteur logic."
-                - *Good*: "🎭 **Smarter Characters**: NPCs now have deeper emotions and agency thanks
-                  to our new narrative engine!"
-            - **Fixes**: A quick mention of polish/fixes.
-            - **Call to Action**: "Update now and start your new saga!"
-        - **Separator**: `---`
-        - **Portuguese Version 🇧🇷**:
-            - Translate the English version, adapting the tone to be natural and exciting in
-              Portuguese.
+3. **Handoff**
+   - Lembrar: colar na Play Console
+   - Não publicar nada automaticamente
 
-3. **Review**:
-    - Present the draft to the user using `notify_user`.
-    - Ask for confirmation.
-
-4. **Finalize**:
-    - Remind the user to copy/paste these into the Google Play Console.
+Referência de tom: `release_1.10.2.md`, `release_1.10.4.md`.

--- a/.cursor/skills/google-play-release-notes/SKILL.md
+++ b/.cursor/skills/google-play-release-notes/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: google-play-release-notes
+description: >-
+  Write Sagas Google Play release notes in a short, sarcastic, petulant voice.
+  Use when the user asks for release notes, Play Console copy, what's new text,
+  or docs/release_notes for sagas-android.
+---
+
+# Google Play release notes (Sagas)
+
+## Regra de ouro
+
+O usuário da Play Store **não quer changelog técnico**. Quer 3–5 frases com personalidade: benefício claro, humor seco, um toque de sarcasmo e petulância (como se o app soubesse que é bom e está fazendo um favor).
+
+**Nunca** na cópia da Play:
+- nomes de classes, flags, APIs, "auto-chain", mutex, ViewModel
+- listas longas de bullet com emoji demais
+- tom de documentação ou marketing corporativo
+
+## Onde salvar
+
+`docs/release_notes/release_[MAJOR.MINOR.PATCH].md` — versão em `version.properties`.
+
+Use `git add -f` (a pasta `docs/` está no `.gitignore`).
+
+## Formato do arquivo
+
+```markdown
+✦ Sagas X.Y.Z — Google Play
+
+🇺🇸 English
+
+[2–4 frases, uma ideia por parágrafo curto. Máx ~500 caracteres se for bloco único para Console.]
+
+🇧🇷 Português
+
+[Mesma energia em PT-BR natural, não tradução literal fria.]
+```
+
+**Opcional** (só se o usuário pedir arquivo interno / Firebase): seção `---` + notas longas para arquivo. Por padrão **não** escrever bloco "Full notes / archive" — manter enxuto.
+
+## Voz (obrigatória)
+
+| Faça | Evite |
+|------|--------|
+| Segunda pessoa ("você") ou "a gente" | "Implementamos", "Refatoramos" |
+| Uma piada ou reviravolta por idioma | Explicar *como* o código funciona |
+| Confiança meio arrogante, leve | Entusiasmo de startup ("incrível!!!") |
+| Frases curtas | Parágrafos de 6 linhas |
+
+**Referência de tom:** `docs/release_notes/release_1.10.2.md`, `release_1.10.4.md`.
+
+### Exemplos de linha
+
+- ✅ "Seu celular virou estéreo sem pedir licença. Agora toca uma vez, nos momentos que importam."
+- ✅ "Chega de segurar o botão duas vezes só pra abrir um ato. O app faz a papelada; você fica com o drama."
+- ❌ "Hybrid in-app banner and system notifications for saga activity."
+- ❌ "Auto-executamos NarrativeAction.CreateAct via requestNarrativeProgression."
+
+## Fluxo
+
+1. Ler `version.properties` e `git log` da branch de release (15 commits ou diff vs `main`).
+2. Agrupar mudanças em **1 tema** para o usuário (ex.: "menos clique", "notificações", "chat menos bugado").
+3. Escrever EN + PT no formato acima; contar caracteres se for colar na Play (limite 500 por idioma).
+4. Entregar o arquivo e lembrar: copiar para Play Console → Release notes.
+
+## Checklist antes de entregar
+
+- [ ] ≤500 caracteres por idioma (se for bloco único Play)
+- [ ] Zero jargão de engenharia
+- [ ] PT soa brasileiro e espirituoso, não traduzido
+- [ ] Algo soa um pouco petulante ou sarcástico (sem ser ofensivo)

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -80,9 +81,12 @@ import com.ilustris.sagai.features.timeline.ui.components.TimelineCharacterAttac
 import com.ilustris.sagai.ui.components.StarryLoader
 import com.ilustris.sagai.ui.components.stylisedText
 import com.ilustris.sagai.ui.components.views.DepthLayout
+import com.ilustris.sagai.ui.theme.SagAITheme
+import com.ilustris.sagai.ui.theme.characterDetailsHeaderScrim
+import com.ilustris.sagai.ui.theme.characterDetailsTitleGradient
 import com.ilustris.sagai.ui.theme.darkerPalette
 import com.ilustris.sagai.ui.theme.fadeGradientBottom
-import com.ilustris.sagai.ui.theme.fadeGradientTop
+import com.ilustris.sagai.ui.theme.fadeGradientTopOverImage
 import com.ilustris.sagai.ui.theme.filters.effectForGenre
 import com.ilustris.sagai.ui.theme.gradientFade
 import com.ilustris.sagai.ui.theme.gradientFill
@@ -101,20 +105,31 @@ fun CharacterDetailsView(
     viewModel: CharacterDetailsViewModel = hiltViewModel(),
 ) {
     val detailData by viewModel.characterDetailData.collectAsStateWithLifecycle()
+    val genre = detailData?.sagaInfo?.genre
 
     LaunchedEffect(characterId) {
         viewModel.loadCharacterDetails(characterId)
     }
 
-    AnimatedContent(detailData, transitionSpec = {
-        slideInVertically { -it } togetherWith fadeOut()
-    }, label = "CharacterDetailsTransition") {
-        if (it != null) {
-            CharacterDetailsContent(
-                it,
-                sharedTransitionScope = sharedTransitionScope,
-                animatedVisibilityScope = animatedVisibilityScope,
-            )
+    DisposableEffect(characterId, detailData?.sagaInfo?.id, detailData?.sagaInfo?.genre) {
+        detailData?.sagaInfo?.let { sagaInfo ->
+            viewModel.onCharacterScreenVisible(sagaInfo.id)
+            viewModel.ensureGenreTheme(sagaInfo.genre)
+        }
+        onDispose { viewModel.onCharacterScreenHidden() }
+    }
+
+    SagAITheme(genre = genre) {
+        AnimatedContent(detailData, transitionSpec = {
+            slideInVertically { -it } togetherWith fadeOut()
+        }, label = "CharacterDetailsTransition") {
+            if (it != null) {
+                CharacterDetailsContent(
+                    it,
+                    sharedTransitionScope = sharedTransitionScope,
+                    animatedVisibilityScope = animatedVisibilityScope,
+                )
+            }
         }
     }
 }
@@ -224,6 +239,11 @@ private fun CharacterDetailsLoaded(
     ) { characterData ->
         var imageError by remember { mutableStateOf(false) }
         val characterColor = characterData.hexColor.hexToColor() ?: resolvedColor
+        val headerScrimColor = characterDetailsHeaderScrim(adaptiveColor, characterColor)
+        val titleGradient =
+            remember(adaptiveTextColor, characterColor) {
+                characterDetailsTitleGradient(adaptiveTextColor, characterColor)
+            }
 
         Box(
             modifier =
@@ -278,11 +298,9 @@ private fun CharacterDetailsLoaded(
                                         Box(
                                             Modifier
                                                 .fillMaxWidth()
-                                                .fillMaxHeight(.2f)
+                                                .fillMaxHeight(0.28f)
                                                 .background(
-                                                    fadeGradientTop(
-                                                        adaptiveColor,
-                                                    ),
+                                                    fadeGradientTopOverImage(headerScrimColor),
                                                 ),
                                         )
                                         genre.stylisedText(
@@ -292,11 +310,8 @@ private fun CharacterDetailsLoaded(
                                                     .align(Alignment.TopCenter)
                                                     .statusBarsPadding()
                                                     .padding(horizontal = 16.dp, vertical = 8.dp)
-                                                    .gradientFill(
-                                                        Brush.verticalGradient(
-                                                            characterColor.darkerPalette(),
-                                                        ),
-                                                    ).reactiveShimmer(
+                                                    .gradientFill(titleGradient)
+                                                    .reactiveShimmer(
                                                         true,
                                                         characterColor.shimmerize(),
                                                     ),

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsViewModel.kt
@@ -3,8 +3,11 @@ package com.ilustris.sagai.features.characters.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.ilustris.sagai.core.data.model.ImagePalette
+import com.ilustris.sagai.core.theme.SagaImmersiveSession
+import com.ilustris.sagai.core.theme.SagaThemeManager
 import com.ilustris.sagai.core.usecase.PaletteUseCase
 import com.ilustris.sagai.features.characters.data.model.Character
+import com.ilustris.sagai.features.newsaga.data.model.Genre
 import com.ilustris.sagai.features.characters.data.model.CharacterArc
 import com.ilustris.sagai.features.characters.data.model.CharacterDetailData
 import com.ilustris.sagai.features.characters.data.model.CharacterSagaInfo
@@ -22,6 +25,8 @@ class CharacterDetailsViewModel
     constructor(
         private val characterUseCase: CharacterUseCase,
         private val paletteUseCase: PaletteUseCase,
+        private val sagaThemeManager: SagaThemeManager,
+        private val sagaImmersiveSession: SagaImmersiveSession,
     ) : ViewModel() {
         val characterDetailData = MutableStateFlow<CharacterDetailData?>(null)
         val imagePalette = MutableStateFlow<ImagePalette?>(null)
@@ -45,6 +50,21 @@ class CharacterDetailsViewModel
 
         /** Job for character arcs collection — cancelled on re-entry. */
         private var arcsJob: Job? = null
+
+        fun onCharacterScreenVisible(sagaId: Int) {
+            sagaImmersiveSession.push("character_detail", sagaId)
+        }
+
+        fun onCharacterScreenHidden() {
+            sagaImmersiveSession.pop("character_detail")
+        }
+
+        /** Re-applies saga genre theme when this screen owns the immersive stack (e.g. after a neutral reset). */
+        fun ensureGenreTheme(genre: Genre) {
+            if (sagaImmersiveSession.isOwnerOnTop("character_detail")) {
+                sagaThemeManager.updateTheme(genre)
+            }
+        }
 
         fun togglePremiumSheet() {
             showPremiumSheet.value = !showPremiumSheet.value
@@ -80,6 +100,7 @@ class CharacterDetailsViewModel
                     characterUseCase.getCharacterDetailData(characterId).collect { data ->
                         characterDetailData.value = data
                         data?.let {
+                            ensureGenreTheme(it.sagaInfo.genre)
                             messageCount.value = it.messageCount
                             if (characterResume.value == null) {
                                 generateResume(it)
@@ -166,5 +187,10 @@ class CharacterDetailsViewModel
                         }
                     }
             }
+        }
+
+        override fun onCleared() {
+            sagaImmersiveSession.pop("character_detail")
+            super.onCleared()
         }
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/NarrativeActionExecutorImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/NarrativeActionExecutorImpl.kt
@@ -245,11 +245,22 @@ class NarrativeActionExecutorImpl
                 )
                 throw IllegalArgumentException("Timeline already set at this chapter")
             }
-            timelineUseCase.saveTimeline(
-                Timeline(
-                    chapterId = currentChapter.data.id,
-                ),
+
+            val savedTimeline =
+                timelineUseCase.saveTimeline(
+                    Timeline(
+                        chapterId = currentChapter.data.id,
+                    ),
+                )
+            chapterUseCase.updateChapter(
+                currentChapter.data.copy(currentEventId = savedTimeline.id),
             )
+
+            val saga = environment.getSagaMetadata() ?: error("Saga not available")
+            when (val objectiveResult = timelineUseCase.getTimelineObjective(saga, savedTimeline)) {
+                is RequestResult.Success -> objectiveResult.value
+                is RequestResult.Error -> throw objectiveResult.value
+            }
         }
 
         private suspend fun updateTimeline(

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -43,6 +43,7 @@ import com.ilustris.sagai.features.home.data.model.getCurrentTimeLine
 import com.ilustris.sagai.features.home.data.usecase.SagaHistoryUseCase
 import com.ilustris.sagai.features.saga.chat.data.model.Message
 import com.ilustris.sagai.features.saga.chat.data.model.SceneSummary
+import com.ilustris.sagai.features.saga.chat.data.model.hasActiveSceneSummary
 import com.ilustris.sagai.features.saga.chat.data.model.SenderType
 import com.ilustris.sagai.features.saga.chat.data.model.hasActiveSceneSummary
 import com.ilustris.sagai.features.saga.chat.data.model.shouldEnsureSceneSummary
@@ -53,8 +54,10 @@ import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeCheck
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeCoordinator
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeEvaluationContext
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionEnvironment
+import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionMode
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionResult
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeUiState
+import com.ilustris.sagai.features.saga.chat.domain.manager.executionMode
 import com.ilustris.sagai.features.saga.chat.presentation.model.IntroductionType
 import com.ilustris.sagai.features.saga.chat.presentation.model.SagaMilestone
 import com.ilustris.sagai.features.saga.datasource.MessageDao
@@ -145,6 +148,7 @@ class SagaContentManagerImpl
         private val managerScope = CoroutineScope(managerJob + Dispatchers.IO)
 
         private var progressionCounter = 0
+        private var autoProgressionChainSteps = 0
 
         private var objectiveEnsureJob: kotlinx.coroutines.Job? = null
 
@@ -168,6 +172,7 @@ class SagaContentManagerImpl
         override suspend fun advanceNarrative() {
             val action = narrativeCoordinator.uiState.value.pendingAction ?: return
             Timber.d("Manually advancing narrative: ${action.javaClass.simpleName}")
+            autoProgressionChainSteps = 0
             narrativeCoordinator.onUserAdvanceRequested(action)
             executeNarrativeAction(action, isRetry = false)
         }
@@ -643,11 +648,20 @@ class SagaContentManagerImpl
                     context = buildEvaluationContext(),
                 )
 
-                if (hydrated is NarrativeAction.CloseTimeline) {
-                    Timber.d("Auto-executing CloseTimeline (chapter pointer only)")
-                    val closeAction = hydrated
-                    managerScope.launch {
-                        executeNarrativeAction(closeAction, isRetry = isRetry)
+                if (hydrated == null) {
+                    autoProgressionChainSteps = 0
+                } else if (hydrated.executionMode() == NarrativeExecutionMode.Automatic) {
+                    if (autoProgressionChainSteps >= MAX_AUTO_PROGRESSION_CHAIN_STEPS) {
+                        Timber.w(
+                            "requestNarrativeProgression: auto chain limit ($MAX_AUTO_PROGRESSION_CHAIN_STEPS) reached at ${hydrated.javaClass.simpleName}",
+                        )
+                    } else {
+                        autoProgressionChainSteps++
+                        Timber.d("Auto-executing narrative setup: ${hydrated.javaClass.simpleName}")
+                        val autoAction = hydrated
+                        managerScope.launch {
+                            executeNarrativeAction(autoAction, isRetry = isRetry)
+                        }
                     }
                 }
 
@@ -897,9 +911,11 @@ class SagaContentManagerImpl
                             timelineUseCase
                                 .getTimelineObjective(content.value!!, timeline)
                                 .getSuccess()
-                        objective?.let {
-                            emitMilestone(SagaMilestone.CurrentObjective(it))
-                        } ?: dismissMilestone()
+                        if (objective != null && objective.hasActiveSceneSummary()) {
+                            emitMilestone(SagaMilestone.CurrentObjective(objective))
+                        } else {
+                            dismissMilestone()
+                        }
                     } ?: dismissMilestone()
                 }
 
@@ -1204,5 +1220,6 @@ class SagaContentManagerImpl
 
         private companion object {
             val TITLE_SPLASH_DURATION = 2.5.seconds
+            const val MAX_AUTO_PROGRESSION_CHAIN_STEPS = 5
         }
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -16,6 +16,7 @@ import com.ilustris.sagai.core.services.RemoteConfigService
 import com.ilustris.sagai.core.services.getNarrativeRules
 import com.ilustris.sagai.core.theme.SagaImmersiveSession
 import com.ilustris.sagai.core.theme.SagaThemeManager
+import com.ilustris.sagai.core.utils.StringResourceHelper
 import com.ilustris.sagai.core.utils.doNothing
 import com.ilustris.sagai.core.utils.emptyString
 import com.ilustris.sagai.core.utils.toRoman
@@ -108,6 +109,7 @@ class SagaContentManagerImpl
         private val sagaImmersiveSession: SagaImmersiveSession,
         private val narrativeCoordinator: NarrativeCoordinator,
         private val narrativeActionExecutor: NarrativeActionExecutor,
+        private val stringResourceHelper: StringResourceHelper,
         @ApplicationContext
         private val context: Context,
     ) : SagaContentManager {
@@ -177,6 +179,31 @@ class SagaContentManagerImpl
             executeNarrativeAction(action, isRetry = false)
         }
 
+        private fun handleNarrativeActionFailure(
+            action: NarrativeAction,
+            canRetry: Boolean = true,
+        ) {
+            autoProgressionChainSteps = 0
+            val userMessage = stringResourceHelper.getString(R.string.unexpected_error)
+            narrativeCoordinator.onActionCompleted(
+                action,
+                NarrativeExecutionResult.Failure(
+                    message = userMessage,
+                    canRetry = canRetry,
+                ),
+            )
+            dismissMilestone()
+            sagaThemeManager.showSnackBar(
+                userMessage,
+                stringResourceHelper.getString(R.string.try_again) to {
+                    managerScope.launch {
+                        narrativeCoordinator.clearError()
+                        executeNarrativeAction(action, isRetry = true)
+                    }
+                },
+            )
+        }
+
         private suspend fun executeNarrativeAction(
             action: NarrativeAction,
             isRetry: Boolean,
@@ -202,20 +229,7 @@ class SagaContentManagerImpl
 
                     is NarrativeExecutionResult.Failure -> {
                         Timber.e("Failed narrative action: ${result.message}")
-                        emitMilestone(null)
-                        if (isRetry) {
-                            sagaThemeManager.showSnackBar(
-                                result.message,
-                                context.getString(R.string.try_again) to {
-                                    managerScope.launch {
-                                        narrativeCoordinator.clearError()
-                                        executeNarrativeAction(action, isRetry = true)
-                                    }
-                                },
-                            )
-                        } else {
-                            executeNarrativeAction(action, isRetry = true)
-                        }
+                        handleNarrativeActionFailure(action, result.canRetry)
                     }
                 }
             } catch (e: Exception) {
@@ -223,11 +237,7 @@ class SagaContentManagerImpl
                     throw e
                 }
                 Timber.e(e, "Unexpected error executing narrative action")
-                narrativeCoordinator.onActionCompleted(
-                    action,
-                    NarrativeExecutionResult.Failure(e.message ?: "Unknown error"),
-                )
-                emitMilestone(null)
+                handleNarrativeActionFailure(action, canRetry = true)
             } finally {
                 narrativeCoordinator.markProcessing(false)
                 setNarrativeProcessingStatus(false)
@@ -901,22 +911,13 @@ class SagaContentManagerImpl
                 }
 
                 is NarrativeAction.CreateTimeline -> {
-                    (resultValue as? Timeline)?.let { timeline ->
-                        chapterUseCase.updateChapter(
-                            saga.currentChapterInfo!!.data.copy(
-                                currentEventId = timeline.id,
-                            ),
-                        )
-                        val objective =
-                            timelineUseCase
-                                .getTimelineObjective(content.value!!, timeline)
-                                .getSuccess()
-                        if (objective != null && objective.hasActiveSceneSummary()) {
-                            emitMilestone(SagaMilestone.CurrentObjective(objective))
-                        } else {
-                            dismissMilestone()
-                        }
-                    } ?: dismissMilestone()
+                    val timeline = resultValue as? Timeline
+                    if (timeline != null && timeline.hasActiveSceneSummary()) {
+                        timeline.sceneSummary?.let { _sceneSummary.value = it }
+                        emitMilestone(SagaMilestone.CurrentObjective(timeline))
+                    } else {
+                        dismissMilestone()
+                    }
                 }
 
                 is NarrativeAction.EvolveTimeline -> {

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
@@ -60,25 +60,24 @@ class NarrativeCoordinator
                         )
                     }
 
-                    is NarrativeAction.CloseTimeline -> {
-                        // Timeline content is already persisted; closing only clears the chapter pointer.
-                        NarrativeUiState(
-                            phase = NarrativePhase.Playing,
-                            pendingAction = null,
-                            backgroundTask = null,
-                            lastError = null,
-                            isProcessing = false,
-                        )
-                    }
-
                     else -> {
-                        NarrativeUiState(
-                            phase = NarrativePhase.AwaitingAdvance(nextAction),
-                            pendingAction = nextAction,
-                            backgroundTask = null,
-                            lastError = null,
-                            isProcessing = false,
-                        )
+                        if (nextAction.executionMode() == NarrativeExecutionMode.Automatic) {
+                            NarrativeUiState(
+                                phase = NarrativePhase.Playing,
+                                pendingAction = null,
+                                backgroundTask = null,
+                                lastError = null,
+                                isProcessing = false,
+                            )
+                        } else {
+                            NarrativeUiState(
+                                phase = NarrativePhase.AwaitingAdvance(nextAction),
+                                pendingAction = nextAction,
+                                backgroundTask = null,
+                                lastError = null,
+                                isProcessing = false,
+                            )
+                        }
                     }
                 }
 
@@ -204,6 +203,17 @@ class NarrativeCoordinator
 
 fun NarrativeAction.executionMode(): NarrativeExecutionMode =
     when (this) {
-        is NarrativeAction.CloseTimeline -> NarrativeExecutionMode.Automatic
-        else -> NarrativeExecutionMode.UserTriggered
+        NarrativeAction.CreateAct,
+        is NarrativeAction.GenerateActIntro,
+        is NarrativeAction.CreateChapter,
+        is NarrativeAction.GenerateChapterIntro,
+        is NarrativeAction.CreateTimeline,
+        is NarrativeAction.CloseTimeline,
+        -> NarrativeExecutionMode.Automatic
+
+        is NarrativeAction.EvolveTimeline,
+        is NarrativeAction.GenerateChapter,
+        is NarrativeAction.GenerateAct,
+        is NarrativeAction.GenerateEnding,
+        -> NarrativeExecutionMode.UserTriggered
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinator.kt
@@ -131,18 +131,8 @@ class NarrativeCoordinator
                 is NarrativeExecutionResult.Failure -> {
                     _uiState.update {
                         it.copy(
-                            phase =
-                                if (action.executionMode() == NarrativeExecutionMode.UserTriggered) {
-                                    NarrativePhase.AwaitingAdvance(action)
-                                } else {
-                                    NarrativePhase.Playing
-                                },
-                            pendingAction =
-                                if (action.executionMode() == NarrativeExecutionMode.UserTriggered) {
-                                    action
-                                } else {
-                                    null
-                                },
+                            phase = NarrativePhase.AwaitingAdvance(action),
+                            pendingAction = action,
                             backgroundTask = null,
                             isProcessing = false,
                             lastError =

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/NarrativeActionUi.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/NarrativeActionUi.kt
@@ -3,6 +3,7 @@ package com.ilustris.sagai.features.saga.chat.presentation.model
 import com.ilustris.sagai.R
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeAction
 import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionMode
+import com.ilustris.sagai.features.saga.chat.domain.manager.executionMode
 
 data class NarrativeActionUi(
     val titleRes: Int,
@@ -10,85 +11,39 @@ data class NarrativeActionUi(
     val executionMode: NarrativeExecutionMode,
 )
 
-fun NarrativeAction.toUi(): NarrativeActionUi =
-    when (this) {
-        is NarrativeAction.EvolveTimeline -> {
-            NarrativeActionUi(
-                R.string.advance_evolve_timeline,
-                R.string.releasing_evolve_timeline,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+fun NarrativeAction.toUi(): NarrativeActionUi {
+    val mode = executionMode()
+    val (titleRes, holdingTextRes) =
+        when (this) {
+            is NarrativeAction.EvolveTimeline ->
+                R.string.advance_evolve_timeline to R.string.releasing_evolve_timeline
 
-        is NarrativeAction.GenerateChapter -> {
-            NarrativeActionUi(
-                R.string.advance_close_chapter,
-                R.string.releasing_close_chapter,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.GenerateChapter ->
+                R.string.advance_close_chapter to R.string.releasing_close_chapter
 
-        is NarrativeAction.CreateChapter -> {
-            NarrativeActionUi(
-                R.string.advance_open_chapter,
-                R.string.releasing_open_chapter,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.CreateChapter ->
+                R.string.advance_open_chapter to R.string.releasing_open_chapter
 
-        is NarrativeAction.GenerateAct -> {
-            NarrativeActionUi(
-                R.string.advance_close_act,
-                R.string.releasing_close_act,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.GenerateAct ->
+                R.string.advance_close_act to R.string.releasing_close_act
 
-        NarrativeAction.CreateAct -> {
-            NarrativeActionUi(
-                R.string.advance_create_act,
-                R.string.releasing_create_act,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            NarrativeAction.CreateAct ->
+                R.string.advance_create_act to R.string.releasing_create_act
 
-        is NarrativeAction.GenerateActIntro -> {
-            NarrativeActionUi(
-                R.string.advance_new_act_introduction,
-                R.string.releasing_act_introduction,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.GenerateActIntro ->
+                R.string.advance_new_act_introduction to R.string.releasing_act_introduction
 
-        is NarrativeAction.GenerateChapterIntro -> {
-            NarrativeActionUi(
-                R.string.advance_new_chapter_introduction,
-                R.string.releasing_chapter_introduction,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.GenerateChapterIntro ->
+                R.string.advance_new_chapter_introduction to R.string.releasing_chapter_introduction
 
-        is NarrativeAction.CreateTimeline -> {
-            NarrativeActionUi(
-                R.string.advance_start_story,
-                R.string.releasing_start_story,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.CreateTimeline ->
+                R.string.advance_start_story to R.string.releasing_start_story
 
-        is NarrativeAction.GenerateEnding -> {
-            NarrativeActionUi(
-                R.string.advance_saga_ending,
-                R.string.releasing_ending,
-                NarrativeExecutionMode.UserTriggered,
-            )
-        }
+            is NarrativeAction.GenerateEnding ->
+                R.string.advance_saga_ending to R.string.releasing_ending
 
-        is NarrativeAction.CloseTimeline -> {
-            NarrativeActionUi(
-                0,
-                R.string.releasing_close_scene,
-                NarrativeExecutionMode.Automatic,
-            )
+            is NarrativeAction.CloseTimeline ->
+                0 to R.string.releasing_close_scene
         }
-    }
+    return NarrativeActionUi(titleRes, holdingTextRes, mode)
+}

--- a/app/src/main/java/com/ilustris/sagai/ui/theme/Gradients.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/theme/Gradients.kt
@@ -124,6 +124,37 @@ fun fadeGradientTop(tintColor: Color = MaterialTheme.colorScheme.background) =
         1f to Color.Transparent,
     )
 
+/** Scrim on top of a portrait (transparent at the top edge → tint), mirrors [fadeGradientBottom]. */
+@Composable
+fun fadeGradientTopOverImage(tintColor: Color = MaterialTheme.colorScheme.background) =
+    Brush.verticalGradient(
+        0f to Color.Transparent,
+        0.4f to tintColor.copy(alpha = 0.3f),
+        0.7f to tintColor.copy(alpha = 0.65f),
+        1f to tintColor.copy(alpha = 0.92f),
+    )
+
+fun Color.blendedWith(
+    other: Color,
+    fraction: Float,
+): Color = androidx.compose.ui.graphics.lerp(this, other, fraction)
+
+/** Header scrim mixing saga adaptive color with character accent for readable titles. */
+fun characterDetailsHeaderScrim(
+    adaptiveColor: Color,
+    characterAccent: Color,
+): Color = adaptiveColor.blendedWith(characterAccent, 0.22f)
+
+fun characterDetailsTitleGradient(
+    legibleOnScrim: Color,
+    characterAccent: Color,
+): Brush =
+    Brush.verticalGradient(
+        0f to legibleOnScrim,
+        0.45f to legibleOnScrim.blendedWith(characterAccent, 0.4f),
+        1f to legibleOnScrim,
+    )
+
 @Composable
 fun fadedGradientTopAndBottom(tintColor: Color = MaterialTheme.colorScheme.background): Brush =
     Brush.verticalGradient(

--- a/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeActionExecutionModeTest.kt
+++ b/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeActionExecutionModeTest.kt
@@ -1,0 +1,37 @@
+package com.ilustris.sagai.features.saga.chat.domain.manager
+
+import com.ilustris.sagai.features.act.data.model.Act
+import com.ilustris.sagai.features.act.data.model.ActContent
+import com.ilustris.sagai.features.chapter.data.model.Chapter
+import com.ilustris.sagai.features.chapter.data.model.ChapterContent
+import com.ilustris.sagai.features.home.data.model.Saga
+import com.ilustris.sagai.features.home.data.model.SagaContent
+import com.ilustris.sagai.features.timeline.data.model.Timeline
+import com.ilustris.sagai.features.timeline.data.model.TimelineContent
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class NarrativeActionExecutionModeTest {
+    private val act = ActContent(data = Act(id = 1, sagaId = 1))
+    private val chapter = ChapterContent(data = Chapter(id = 1, actId = 1))
+    private val timeline = TimelineContent(data = Timeline(id = 1, chapterId = 1))
+    private val saga = SagaContent(data = Saga(id = 1))
+
+    @Test
+    fun `structural setup actions are automatic`() {
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.CreateAct.executionMode())
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.GenerateActIntro(act).executionMode())
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.CreateChapter(act).executionMode())
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.GenerateChapterIntro(chapter).executionMode())
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.CreateTimeline(chapter).executionMode())
+        assertEquals(NarrativeExecutionMode.Automatic, NarrativeAction.CloseTimeline(chapter).executionMode())
+    }
+
+    @Test
+    fun `narrative payoff actions require user advance`() {
+        assertEquals(NarrativeExecutionMode.UserTriggered, NarrativeAction.EvolveTimeline(timeline).executionMode())
+        assertEquals(NarrativeExecutionMode.UserTriggered, NarrativeAction.GenerateChapter(chapter).executionMode())
+        assertEquals(NarrativeExecutionMode.UserTriggered, NarrativeAction.GenerateAct(act).executionMode())
+        assertEquals(NarrativeExecutionMode.UserTriggered, NarrativeAction.GenerateEnding(saga).executionMode())
+    }
+}

--- a/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
+++ b/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
@@ -3,6 +3,7 @@ package com.ilustris.sagai.features.saga.chat.domain.manager
 import com.ilustris.sagai.features.act.data.model.Act
 import com.ilustris.sagai.features.act.data.model.ActContent
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -11,21 +12,45 @@ class NarrativeCoordinatorTest {
     private val coordinator = NarrativeCoordinator()
 
     @Test
-    fun `reevaluate exposes user action`() {
+    fun `reevaluate exposes user action for evolve timeline`() {
+        val timeline =
+            com.ilustris.sagai.features.timeline.data.model.TimelineContent(
+                data =
+                    com.ilustris.sagai.features.timeline.data.model.Timeline(
+                        id = 1,
+                        chapterId = 1,
+                    ),
+                messages = emptyList(),
+            )
+        val state =
+            coordinator.reevaluate(
+                nextResolvedAction = NarrativeAction.EvolveTimeline(timeline),
+                context = NarrativeEvaluationContext(),
+            )
+
+        assertTrue(state.pendingAction is NarrativeAction.EvolveTimeline)
+        assertTrue(state.phase is NarrativePhase.AwaitingAdvance)
+    }
+
+    @Test
+    fun `reevaluate does not await advance for structural setup actions`() {
         val state =
             coordinator.reevaluate(
                 nextResolvedAction = NarrativeAction.CreateAct,
                 context = NarrativeEvaluationContext(),
             )
 
-        assertTrue(state.pendingAction is NarrativeAction.CreateAct)
-        assertTrue(state.phase is NarrativePhase.AwaitingAdvance)
+        assertNull(state.pendingAction)
+        assertTrue(state.phase is NarrativePhase.Playing)
+        assertFalse(state.showAdvanceTrigger)
     }
 
     @Test
     fun `failure restores awaiting advance for user actions`() {
-        val act = ActContent(data = Act(id = 1, sagaId = 1))
-        val action = NarrativeAction.GenerateActIntro(act)
+        val chapter = com.ilustris.sagai.features.chapter.data.model.ChapterContent(
+            data = com.ilustris.sagai.features.chapter.data.model.Chapter(id = 1, actId = 1),
+        )
+        val action = NarrativeAction.GenerateChapter(chapter)
 
         coordinator.onUserAdvanceRequested(action)
         coordinator.onActionCompleted(

--- a/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
+++ b/app/src/test/java/com/ilustris/sagai/features/saga/chat/domain/manager/NarrativeCoordinatorTest.kt
@@ -46,6 +46,20 @@ class NarrativeCoordinatorTest {
     }
 
     @Test
+    fun `failure restores awaiting advance for automatic setup actions`() {
+        coordinator.onUserAdvanceRequested(NarrativeAction.CreateAct)
+        coordinator.onActionCompleted(
+            NarrativeAction.CreateAct,
+            NarrativeExecutionResult.Failure("network"),
+        )
+
+        val state = coordinator.uiState.value
+        assertTrue(state.pendingAction is NarrativeAction.CreateAct)
+        assertTrue(state.phase is NarrativePhase.AwaitingAdvance)
+        assertTrue(state.showAdvanceTrigger)
+    }
+
+    @Test
     fun `failure restores awaiting advance for user actions`() {
         val chapter = com.ilustris.sagai.features.chapter.data.model.ChapterContent(
             data = com.ilustris.sagai.features.chapter.data.model.Chapter(id = 1, actId = 1),

--- a/docs/release_notes/release_1.10.3.md
+++ b/docs/release_notes/release_1.10.3.md
@@ -1,93 +1,21 @@
-✦ Sagas 1.10.3 — Google Play (≤500 chars per language)
-
-Copy the block below into Play Console → Release → Release notes.
-
----
-
-🇺🇸 English (498 chars)
-
-```
-Your long messages finally reach the AI—no more silent truncation at 500 characters.
-
-Stay in the story: in-app banners and notifications when your saga moves, even off the chat screen.
-
-Faster sends, synced character portraits, smoother new-saga creation, and ambient music that survives a trip to the background.
-
-Stopping generation won't ghost your saga. Chat loading is clearer. Update and keep writing.
-```
-
----
-
-🇧🇷 Português (499 chars)
-
-```
-Mensagens longas chegam inteiras na IA—sem cortar em 500 caracteres no escuro.
-
-Fique no loop: banner no app e notificações quando a saga avança, mesmo fora do chat.
-
-Envio mais rápido, avatares sincronizados, criação de saga mais fluida e trilha que aguenta ir pro background.
-
-Parar a geração não apaga sua saga. Carregamento do chat mais claro. Atualiza e continua escrevendo.
-```
-
----
-
-✦ Full notes (archive / Firebase — not for Play)
+✦ Sagas 1.10.3 — Google Play
 
 🇺🇸 English
 
-✍️ **Your words, all of them**
+Your long messages finally reach the AI—no more dying at 500 characters in secret.
 
-Messages and chat history were clipped before they reached the AI—awkward when the app lets you type up to 2000 characters. Long replies now stay intact in prompts.
+We'll ping you when your saga moves (banner in-app or notification), even if you're lurking on another screen.
 
-🔔 **Never miss a plot twist**
+Faster chat, synced faces, music that survives going to the background, and stopping generation without the app gaslighting you into "saga not found."
 
-Hybrid notifications: WhatsApp-style in-app banner when you're elsewhere in the app, system alerts when Sagas is in the background. Milestones on new chapters, acts, and timelines.
-
-⚡ **Chat that keeps up**
-
-Instant send (no artificial delay), immersive theme owned by the screen you're on, and CHAT notifications that respect your settings.
-
-🎭 **Faces in the crowd**
-
-Character avatars refresh when the roster changes; new NPCs link to their first AI appearance. Cleaner portraits without heavy smart-zoom on tiny icons.
-
-📖 **New saga, new polish**
-
-Chronicle-style book focus and live reasoning while your world generates. Ambient music resumes safely after backgrounding—no crash surprises.
-
-🛑 **Stop without panic**
-
-Cancel generation without wiping the current saga. Clearer loading vs "saga not found" when switching stories.
-
-That's 1.10.3—polish, presence, and fewer "what just happened?" moments.
-
----
+Update. Write something unhinged.
 
 🇧🇷 Português
 
-✍️ **Suas palavras, inteiras**
+Mensagens longas chegam inteiras na IA—sem morrer em 500 caracteres no escuro.
 
-Mensagens e histórico eram cortados antes da IA—estranho com limite de 2000 no app. Respostas longas agora vão completas pro modelo.
+A gente te avisa quando a saga anda (banner ou notificação), mesmo se você estiver em outra tela.
 
-🔔 **Não perca o próximo capítulo**
+Chat mais rápido, rostos certos, trilha que aguenta o background, e parar a geração sem o app fingir que a saga sumiu.
 
-Notificações híbridas: banner no app estilo WhatsApp quando você está em outra tela, alerta no sistema com o app em background. Marcos em capítulos, atos e eventos.
-
-⚡ **Chat no ritmo certo**
-
-Envio instantâneo, tema imersivo só na tela ativa, e notificações de chat que respeitam suas preferências.
-
-🎭 **Rostos certos na conversa**
-
-Avatares atualizam quando o elenco muda; personagens novos ligam à primeira fala da IA. Retratos mais limpos sem smart zoom pesado em ícones pequenos.
-
-📖 **Nova saga com mais cara**
-
-Foco no livro e raciocínio ao vivo na criação. Trilha ambiente volta com segurança depois do background—sem susto de crash.
-
-🛑 **Parar sem apagar tudo**
-
-Cancelar geração sem perder a saga atual. Carregamento mais claro vs "saga não encontrada" ao trocar de história.
-
-É a 1.10.3—presença, polimento e menos "o que aconteceu?".
+Atualiza. Escreve algo absurdo.

--- a/docs/release_notes/release_1.10.4.md
+++ b/docs/release_notes/release_1.10.4.md
@@ -1,0 +1,17 @@
+✦ Sagas 1.10.4 — Google Play
+
+🇺🇸 English
+
+We were tired of making you hold a button twice just to start a new act, chapter, or scene. The app handles the paperwork now. You save the dramatic button for when the story actually earns it.
+
+Also: we only flash an objective when there's something worth reading—not an empty banner pretending to be deep.
+
+You're welcome. Update.
+
+🇧🇷 Português
+
+A gente cansou de você segurar o botão duas vezes só pra abrir ato, capítulo ou cena. O app faz a burocracia. O botão dramático fica pros momentos que a história merece.
+
+Objetivo só aparece quando tem texto de verdade—sem banner vazio com cara de profundo.
+
+De nada. Atualiza.

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 # Version components following MAJOR.MINOR.PATCH convention
 MAJOR=1
 MINOR=10
-PATCH=3
+PATCH=4


### PR DESCRIPTION
## Summary

- Structural narrative steps (`CreateAct`, `GenerateActIntro`, `CreateChapter`, `GenerateChapterIntro`, `CreateTimeline`, `CloseTimeline`) now run automatically, like `CloseTimeline` already did — users no longer need two Advance holds before act/chapter intros or a new event objective.
- User-triggered flow is unchanged for high-cost beats: `EvolveTimeline`, `GenerateChapter`, `GenerateAct`, and `GenerateEnding` still use the hold-to-advance trigger and existing milestone Continue buttons.
- `CurrentObjective` is only shown when the timeline has a valid scene summary (`hasActiveSceneSummary()`), avoiding empty objective banners.
- Version bump to **1.10.4** in `version.properties`.

## Technical notes

- `NarrativeAction.executionMode()` classifies setup vs payoff actions.
- `SagaContentManagerImpl.requestNarrativeProgression` auto-launches automatic actions with a chain limit of 5 steps per progression cycle.
- `NarrativeCoordinator.reevaluate` no longer exposes `AwaitingAdvance` for automatic actions (no `AdvanceTrigger` flash).

## Test plan

- [ ] New saga: first act → chapter → event without double Advance hold; intro/objective overlays still appear
- [ ] Existing saga: switch between sagas — no regression on loading vs "saga not found"
- [ ] Stop generation during AI reply — saga content stays loaded
- [ ] `EvolveTimeline` still requires Advance hold + `NewEvent` Continue
- [ ] Chapter/act completion still requires Advance + cinematic Continue
- [ ] Unit tests: `./gradlew :app:testDebugUnitTest --tests "com.ilustris.sagai.features.saga.chat.domain.manager.*"`


Made with [Cursor](https://cursor.com)