### PR TITLE
fix: 1.10.6 hotfix — null titleRes crash and UI polish

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/MainActivity.kt
+++ b/app/src/main/java/com/ilustris/sagai/MainActivity.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -58,6 +59,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.ui.NavDisplay
+import androidx.navigation3.ui.LocalNavAnimatedContentScope
 import com.google.firebase.installations.FirebaseInstallations
 import com.ilustris.sagai.core.data.SideEffect
 import com.ilustris.sagai.core.network.ConnectivityObserver
@@ -313,10 +315,26 @@ class MainActivity : ComponentActivity() {
                                             )
                                         }
                                     Box(modifier = Modifier.fillMaxSize()) {
-                                        NavDisplay(
-                                            entries = navigationState.toEntries(entryProvider),
-                                            onBack = { navigator.goBack() },
-                                        )
+                                        // Provide a navigation-specific AnimatedContent scope so
+                                        // all entries can use the same default transition (crossfade).
+                                        AnimatedContent(
+                                            targetState = resolveCurrentKey(),
+                                            transitionSpec = { fadeIn() togetherWith fadeOut() },
+                                        ) {
+                                            // `this` is an AnimatedContentScope — provide it to
+                                            // navigation entries via LocalNavAnimatedContentScope
+                                            CompositionLocalProvider(
+                                                LocalNavAnimatedContentScope provides this,
+                                            ) {
+                                                NavDisplay(
+                                                    entries =
+                                                        navigationState.toEntries(
+                                                            entryProvider,
+                                                        ),
+                                                    onBack = { navigator.goBack() },
+                                                )
+                                            }
+                                        }
 
                                         SagaInAppNotificationBanner(
                                             notification = inAppNotification,

--- a/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/characters/ui/CharacterDetailsView.kt
@@ -18,9 +18,9 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredWidthIn
 import androidx.compose.foundation.layout.size
@@ -86,12 +86,13 @@ import com.ilustris.sagai.ui.theme.characterDetailsHeaderScrim
 import com.ilustris.sagai.ui.theme.characterDetailsTitleGradient
 import com.ilustris.sagai.ui.theme.darkerPalette
 import com.ilustris.sagai.ui.theme.fadeGradientBottom
-import com.ilustris.sagai.ui.theme.fadeGradientTopOverImage
+import com.ilustris.sagai.ui.theme.fadeGradientTop
 import com.ilustris.sagai.ui.theme.filters.effectForGenre
 import com.ilustris.sagai.ui.theme.gradientFade
 import com.ilustris.sagai.ui.theme.gradientFill
 import com.ilustris.sagai.ui.theme.hexToColor
 import com.ilustris.sagai.ui.theme.reactiveShimmer
+import com.ilustris.sagai.ui.theme.sagaBrush
 import com.ilustris.sagai.ui.theme.sagaShape
 import com.ilustris.sagai.ui.theme.shimmerize
 
@@ -291,25 +292,37 @@ private fun CharacterDetailsLoaded(
                                             .effectForGenre(
                                                 genre,
                                             ).graphicsLayer(
-                                                translationY = 120f,
+                                                translationY = 100f,
                                             ),
                                 ) {
-                                    Box(Modifier.fillMaxSize()) {
-                                        Box(
-                                            Modifier
-                                                .fillMaxWidth()
-                                                .fillMaxHeight(0.28f)
-                                                .background(
-                                                    fadeGradientTopOverImage(headerScrimColor),
-                                                ),
-                                        )
+                                    Box(
+                                        Modifier.fillMaxSize(),
+                                        contentAlignment = Alignment.TopCenter,
+                                    ) {
+                                        Column {
+                                            Box(
+                                                Modifier
+                                                    .background(adaptiveColor)
+                                                    .fillMaxWidth()
+                                                    .height(50.dp),
+                                            )
+                                            Box(
+                                                Modifier
+                                                    .background(fadeGradientTop(adaptiveColor))
+                                                    .fillMaxWidth()
+                                                    .height(50.dp),
+                                            )
+                                        }
+
                                         genre.stylisedText(
                                             text = "${characterData.name} ${(characterData.lastName ?: emptyString())}".trim(),
                                             modifier =
                                                 Modifier
-                                                    .align(Alignment.TopCenter)
+                                                    .background(
+                                                        fadeGradientTop(adaptiveColor),
+                                                    ).fillMaxWidth()
                                                     .statusBarsPadding()
-                                                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                                                    .padding(horizontal = 16.dp, vertical = 4.dp)
                                                     .gradientFill(titleGradient)
                                                     .reactiveShimmer(
                                                         true,
@@ -336,6 +349,7 @@ private fun CharacterDetailsLoaded(
                                             .padding(top = 16.dp)
                                             .size(24.dp)
                                             .clip(CircleShape)
+                                            .gradientFill(sagaBrush())
                                             .clickable { showCharacterShare = true },
                                     colorFilter = ColorFilter.tint(characterColor),
                                 )
@@ -389,8 +403,7 @@ private fun CharacterDetailsLoaded(
                                             sagaInfo,
                                             characterData,
                                         )
-                                    }
-                                    .padding(16.dp)
+                                    }.padding(16.dp)
                                     .size(100.dp)
                                     .gradientFill(characterColor.gradientFade()),
                             )
@@ -517,8 +530,7 @@ private fun CharacterDetailsLoaded(
                                             isSummarizing,
                                             targetValue = 1000f,
                                             repeatMode = RepeatMode.Restart,
-                                        )
-                                        .padding(vertical = 16.dp),
+                                        ).padding(vertical = 16.dp),
                             )
                         }
                     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/NarrativeActionUi.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/model/NarrativeActionUi.kt
@@ -6,7 +6,7 @@ import com.ilustris.sagai.features.saga.chat.domain.manager.NarrativeExecutionMo
 import com.ilustris.sagai.features.saga.chat.domain.manager.executionMode
 
 data class NarrativeActionUi(
-    val titleRes: Int,
+    val titleRes: Int?,
     val holdingTextRes: Int,
     val executionMode: NarrativeExecutionMode,
 )
@@ -15,37 +15,47 @@ fun NarrativeAction.toUi(): NarrativeActionUi {
     val mode = executionMode()
     val (titleRes, holdingTextRes) =
         when (this) {
-            is NarrativeAction.EvolveTimeline ->
+            is NarrativeAction.EvolveTimeline -> {
                 R.string.advance_evolve_timeline to R.string.releasing_evolve_timeline
+            }
 
-            is NarrativeAction.GenerateChapter ->
+            is NarrativeAction.GenerateChapter -> {
                 R.string.advance_close_chapter to R.string.releasing_close_chapter
+            }
 
-            is NarrativeAction.CreateChapter ->
+            is NarrativeAction.CreateChapter -> {
                 R.string.advance_open_chapter to R.string.releasing_open_chapter
+            }
 
-            is NarrativeAction.GenerateAct ->
+            is NarrativeAction.GenerateAct -> {
                 R.string.advance_close_act to R.string.releasing_close_act
+            }
 
-            NarrativeAction.CreateAct ->
+            NarrativeAction.CreateAct -> {
                 R.string.advance_create_act to R.string.releasing_create_act
+            }
 
-            is NarrativeAction.GenerateActIntro ->
+            is NarrativeAction.GenerateActIntro -> {
                 R.string.advance_new_act_introduction to R.string.releasing_act_introduction
+            }
 
-            is NarrativeAction.GenerateChapterIntro ->
+            is NarrativeAction.GenerateChapterIntro -> {
                 R.string.advance_new_chapter_introduction to R.string.releasing_chapter_introduction
+            }
 
             is NarrativeAction.CreateTimeline,
             is NarrativeAction.EnsureTimelineSceneSummary,
-            ->
+            -> {
                 R.string.advance_start_story to R.string.releasing_start_story
+            }
 
-            is NarrativeAction.GenerateEnding ->
+            is NarrativeAction.GenerateEnding -> {
                 R.string.advance_saga_ending to R.string.releasing_ending
+            }
 
-            is NarrativeAction.CloseTimeline ->
-                0 to R.string.releasing_close_scene
+            is NarrativeAction.CloseTimeline -> {
+                null to R.string.releasing_close_scene
+            }
         }
     return NarrativeActionUi(titleRes, holdingTextRes, mode)
 }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/ChatView.kt
@@ -164,6 +164,7 @@ import com.ilustris.sagai.ui.animations.StarryTextPlaceholder
 import com.ilustris.sagai.ui.animations.genreVfx
 import com.ilustris.sagai.ui.components.stylisedText
 import com.ilustris.sagai.ui.components.views.DepthLayout
+import com.ilustris.sagai.ui.theme.GradientType
 import com.ilustris.sagai.ui.theme.SagAITheme
 import com.ilustris.sagai.ui.theme.components.SagaTopBar
 import com.ilustris.sagai.ui.theme.components.SparkIcon
@@ -178,6 +179,7 @@ import com.ilustris.sagai.ui.theme.holographicGradient
 import com.ilustris.sagai.ui.theme.levitate
 import com.ilustris.sagai.ui.theme.progressiveBrush
 import com.ilustris.sagai.ui.theme.reactiveShimmer
+import com.ilustris.sagai.ui.theme.sagaBrush
 import com.ilustris.sagai.ui.theme.sagaHighlight
 import com.ilustris.sagai.ui.theme.themeShimmer
 import kotlinx.coroutines.launch
@@ -1118,7 +1120,10 @@ private fun SagaChatSparkPlaceholder(modifier: Modifier = Modifier) {
         Icon(
             painter = painterResource(R.drawable.ic_spark),
             contentDescription = null,
-            modifier = Modifier.size(48.dp),
+            modifier =
+                Modifier
+                    .size(48.dp)
+                    .gradientFill(sagaBrush(gradientType = GradientType.VERTICAL)),
             tint = muted,
         )
     }

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/milestone/AdvanceTrigger.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/ui/components/milestone/AdvanceTrigger.kt
@@ -167,7 +167,7 @@ fun AdvanceTrigger(
                                 if (isHolding) {
                                     stringResource(actionUi.holdingTextRes)
                                 } else {
-                                    stringResource(actionUi.titleRes)
+                                    stringResource(actionUi.titleRes ?: R.string.continue_text)
                                 }.uppercase(),
                             style =
                                 MaterialTheme.typography.labelLarge.copy(

--- a/app/src/main/java/com/ilustris/sagai/ui/components/WordArt.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/WordArt.kt
@@ -58,6 +58,7 @@ import com.ilustris.sagai.ui.animations.genreVfx
 import com.ilustris.sagai.ui.theme.SagAIScaffold
 import com.ilustris.sagai.ui.theme.darker
 import com.ilustris.sagai.ui.theme.lighter
+import com.ilustris.sagai.ui.theme.themeBrushColors
 
 @Composable
 fun WordArtText(
@@ -286,9 +287,9 @@ fun Genre.stylisedText(
     fontSize: TextUnit = MaterialTheme.typography.displaySmall.fontSize,
     visualConfig: GenreVisualConfig? = null,
 ) {
-    val resolvedColor = resolveColor(visualConfig)
-    val resolvedIconColor = resolveIconColor(visualConfig)
-    val palette = colorPalette(visualConfig)
+    val resolvedColor = MaterialTheme.colorScheme.primary
+    val resolvedIconColor = MaterialTheme.colorScheme.onPrimary
+    val palette = themeBrushColors()
     val style =
         MaterialTheme.typography.displaySmall.copy(
             textAlign = TextAlign.Center,

--- a/docs/release_notes/release_1.10.6.md
+++ b/docs/release_notes/release_1.10.6.md
@@ -1,0 +1,17 @@
+✦ Sagas 1.10.6 — Google Play
+
+🇺🇸 English
+
+We shipped 1.10.5, opened the app, and immediately found a crash hiding behind a button. Fixed. Closing a scene won't take the whole app with it anymore.
+
+Also tightened the visuals: smoother screen transitions, character page header that actually frames the name, and a chat spark that finally looks the way it was drawn.
+
+Small patch, big difference. Update.
+
+🇧🇷 Português
+
+A gente lançou a 1.10.5, abriu o app e achou um crash escondido atrás de um botão. Resolvido. Fechar uma cena não derruba mais a casa.
+
+E demos um trato no visual: transição de tela mais suave, header da página de personagem enquadrando o nome direito, e o spark do chat finalmente parecendo o que foi desenhado.
+
+Patch pequeno, diferença grande. Atualiza.

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 # Version components following MAJOR.MINOR.PATCH convention
 MAJOR=1
 MINOR=10
-PATCH=5
+PATCH=6


### PR DESCRIPTION
## Summary
- Fix crash in AdvanceTrigger when a NarrativeAction had no title (CloseTimeline): `titleRes` is now nullable and falls back to `continue_text`.
- Wrap NavDisplay with an AnimatedContent + LocalNavAnimatedContentScope so navigation transitions crossfade consistently.
- Polish CharacterDetailsView header gradient and title framing; share icon adopts the saga brush.
- Apply gradient fill to the chat spark placeholder.
- Make `Genre.stylisedText` follow the current theme colors instead of forced genre palette.
- Bump version to 1.10.6 and add Google Play release notes.

## Test plan
- [ ] Open the chat with a closing scene — no crash on AdvanceTrigger, "Continue" label appears
- [ ] Navigate between saga detail / chat / character details — transitions crossfade
- [ ] Open character details — header gradient frames the name; share icon uses saga brush
- [ ] Open chat while loading — spark placeholder shows gradient fill

Made with [Cursor](https://cursor.com)