### PR TITLE
Fix narrative progression getting stuck behind generation/milestone locks

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -785,9 +785,23 @@ class SagaContentManagerImpl
             val showAdvance =
                 narrativeState.showAdvanceTrigger && advanceAction != null && !advanceSuppressed
 
+            // A NewEvent/ChapterFinished/ActFinished/Introduction reveal blocks narrative
+            // reevaluation until the user taps its own in-content continue button (buried in the
+            // top island's expanded body), otherwise nothing ever progresses. Surface the same
+            // continue affordance as a persistent bottom pill too, so the user always has an
+            // obvious way forward — tapping it just runs the same reset continueMilestone() would.
+            val milestoneAwaitingContinue =
+                !advanceSuppressed &&
+                    (
+                        milestone is SagaMilestone.NewEvent ||
+                            milestone is SagaMilestone.ChapterFinished ||
+                            milestone is SagaMilestone.ActFinished ||
+                            milestone is SagaMilestone.Introduction
+                    )
+
             val bottomContent: IslandContent? =
                 when {
-                    showAdvance && advanceAction != null ->
+                    showAdvance ->
                         AdvanceIslandContent(
                             action = advanceAction,
                             reasoning = reasoning,
@@ -796,6 +810,15 @@ class SagaContentManagerImpl
                             onAction = {
                                 if (!isProcessing) managerScope.launch { advanceNarrative() }
                             },
+                        )
+
+                    milestoneAwaitingContinue ->
+                        AdvanceIslandContent(
+                            action = null,
+                            reasoning = reasoning,
+                            isProcessing = false,
+                            genre = genre,
+                            onAction = { managerScope.launch { continueMilestone() } },
                         )
 
                     else -> null

--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/presentation/ChatViewModel.kt
@@ -494,14 +494,18 @@ class ChatViewModel
 
         /**
          * Forwards gating the manager can't see on its own (onboarding overlays, message-selection
-         * mode, chat-reply generation) into the advance-trigger island's suppression flag — the
-         * chat screen just relays its own state, the manager owns everything else about when/what
-         * island to publish.
+         * mode) into the advance-trigger island's suppression flag — the chat screen just relays
+         * its own state, the manager owns everything else about when/what island to publish.
+         *
+         * Chat-reply generation is deliberately NOT a suppression reason: tapping advance while a
+         * reply is still streaming is safe, since the AI client already serializes requests behind
+         * its own per-model mutex (see GeminiGenerationEngine's requestMutexes), so an advance
+         * action queued mid-generation simply waits its turn instead of racing it.
          */
         private fun observeAdvanceTriggerSuppression() =
             viewModelScope.launch(Dispatchers.IO) {
                 uiState
-                    .map { it.onboardingType != null || it.selectionState.isSelectionMode || it.isGenerating }
+                    .map { it.onboardingType != null || it.selectionState.isSelectionMode }
                     .distinctUntilChanged()
                     .collect { suppressed -> sagaContentManager.setAdvanceTriggerSuppressed(suppressed) }
             }

--- a/app/src/main/java/com/ilustris/sagai/ui/components/island/AdvanceIslandContent.kt
+++ b/app/src/main/java/com/ilustris/sagai/ui/components/island/AdvanceIslandContent.kt
@@ -14,20 +14,29 @@ import com.ilustris.sagai.features.saga.chat.presentation.model.toUi
  * processing, it shows the streaming reasoning (marquee-scrolling if long) with the trailing
  * arrow swapped for the loading spinner — the same "reasoning lives in the compact pill, no
  * separate expanded body" pattern used for image generation.
+ *
+ * [action] is null for the "continue past milestone" fallback (a blocking milestone reveal with
+ * no resolved narrative action yet) — in that case the pill just shows a generic continue label
+ * instead of an action-specific one.
  */
 class AdvanceIslandContent(
-    private val action: NarrativeAction,
+    private val action: NarrativeAction?,
     private val reasoning: String?,
     private val isProcessing: Boolean,
     private val genre: Genre?,
     override val onAction: () -> Unit,
 ) : IslandContent {
-    private val actionUi = action.toUi()
+    private val actionUi = action?.toUi()
 
     override val compact: CompactIslandData =
         CompactIslandData(
             label = if (isProcessing) reasoning else null,
-            labelRes = if (isProcessing) actionUi.holdingTextRes else (actionUi.titleRes ?: R.string.continue_text),
+            labelRes =
+                if (isProcessing) {
+                    actionUi?.holdingTextRes ?: R.string.continue_text
+                } else {
+                    actionUi?.titleRes ?: R.string.continue_text
+                },
             iconRes = genre?.icon,
             isLoading = isProcessing,
             actionIconRes = if (isProcessing) null else R.drawable.round_arrow_forward_ios_24,


### PR DESCRIPTION
## Summary
- `ChatViewModel.observeAdvanceTriggerSuppression()` was hiding the "advance narrative" pill whenever `isGenerating` was true, even after a timeline already reached its message limit — so the button often failed to reappear until the current chat reply finished generating (and could get stuck given how `isGenerating` is written from two independent flows). Removed chat-reply generation as a suppression reason: `advanceNarrative()` already guards against concurrent narrative actions (`isProcessingNarrative`), and any AI call it triggers is serialized behind the AI client's own per-model request mutex (`GeminiGenerationEngine.requestMutexes`), so tapping advance mid-generation just queues behind the in-flight request instead of racing it. Onboarding overlays and message-selection mode remain valid suppression reasons.
- Separately: a `NewEvent`/`ChapterFinished`/`ActFinished`/`Introduction` milestone reveal holds narrative reevaluation in `MilestoneBlocking` until the user taps its own continue button — buried inside the top island's expanded body. If the user never expands it, there was no other visible way forward. Now the same continue affordance also surfaces as a persistent bottom pill (`AdvanceIslandContent` with a null action, generic "continue" label); tapping it runs the exact same reset `continueMilestone()` already does (dismiss + the milestone-type-specific follow-up), so it's equivalent to tapping continue on the milestone island itself.

## Test plan
- [ ] Manually verify: send a message so the timeline hits `loreUpdateLimit` while the AI reply is still streaming, confirm the advance pill appears promptly without waiting for generation to finish.
- [ ] Manually verify: tap advance while a reply is still generating, confirm the narrative action executes correctly once the in-flight generation completes (no duplicate/racing requests).
- [ ] Manually verify: trigger a NewEvent/ChapterFinished/ActFinished/Introduction milestone, don't expand or continue it from the top island, confirm the bottom continue pill appears and tapping it resolves the milestone and lets the story progress.
- Was not able to build/run the app in this cloud sandbox (offline, no JDK 17 toolchain available to Gradle here), so this needs manual verification on a machine with the full toolchain.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NEovShEZC46bCXhzvw7j16