### PR TITLE
Fix duplicate event creation and slow next-event transition

### DIFF
--- a/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
+++ b/app/src/main/java/com/ilustris/sagai/features/saga/chat/data/manager/SagaContentManagerImpl.kt
@@ -845,7 +845,6 @@ class SagaContentManagerImpl
                 return
             }
 
-            var hydrated: NarrativeAction? = null
             // Whether another reevaluation was queued *while we held the lock*. Consumed here but
             // acted on below, outside withLock — recursing from inside it would always see the
             // mutex as locked (by ourselves) and just re-queue forever without ever re-checking.
@@ -875,7 +874,7 @@ class SagaContentManagerImpl
                 // it — same underlying race as the duplicate-timeline guard, just cosmetic instead
                 // of thrown.
                 val intent = NarrativeCheck.validateProgressionMetadata(sagaContent.toNarrativeMetadata(), rules)
-                hydrated =
+                val hydrated =
                     intent?.let { NarrativeActionMaterializer.materialize(it, sagaContent) }
                 if (intent != null && hydrated == null) {
                     Timber.w(
@@ -892,12 +891,24 @@ class SagaContentManagerImpl
                     isAutomatic = isAutomatic,
                 )
 
+                // Automatic actions (e.g. CreateTimeline) run right here, still holding the lock,
+                // instead of after releasing it. Several reactive triggers (milestone dismissal,
+                // loading state, the explicit continue call) can each independently ask for a
+                // progression check around the same time; running the resolved action outside the
+                // lock let two of them resolve the *same* automatic action off snapshots that
+                // hadn't caught up with each other's write yet, occasionally creating the next
+                // timeline twice. A nested requestNarrativeProgression() call triggered from inside
+                // execution (e.g. its Success branch) just sees the mutex still locked and defers
+                // via schedulePendingReevaluation() instead of recursing — consumed below once this
+                // section releases the lock, so nothing gets lost, it just resolves off fresh data.
+                if (hydrated != null && isAutomatic) {
+                    executeNarrativeAction(hydrated, isRetry = false)
+                }
+
                 shouldReevaluateAgain = narrativeCoordinator.consumePendingReevaluation()
             }
 
-            if (hydrated != null && hydrated.executionMode() == NarrativeExecutionMode.Automatic) {
-                executeNarrativeAction(hydrated, isRetry = false)
-            } else if (shouldReevaluateAgain) {
+            if (shouldReevaluateAgain) {
                 requestNarrativeProgression(isRetry = false)
             }
         }


### PR DESCRIPTION
## Summary
- `CreateTimeline` (and any other `Automatic`-mode narrative action) was executed **after** `requestNarrativeProgression()` released `progressionMutex`, not while holding it. Several reactive triggers (milestone dismissal, loading state, the explicit continue call) can each independently ask for a progression check around the same time — each would acquire the mutex just to compute the next action, release it, then execute, so two callers could resolve the *same* automatic action off saga snapshots that hadn't caught up with each other's write yet. Occasionally this created the next (empty) event/timeline twice.
- The existing "timeline already active" self-heal (throwing/catching `TIMELINE_ALREADY_ACTIVE_MESSAGE`) only catches this when the second run's action snapshot happens to already reflect the first run's write — it doesn't reliably, since that snapshot is captured once at materialization time and never re-read inside the executor.
- Fix: run the automatic execution **inside** the same `withLock` section that resolved it. A concurrent caller now sees the mutex still locked and defers via `schedulePendingReevaluation()` instead of racing to execute — it gets picked up right after the lock releases, resolving off fresh data instead of a stale duplicate.
- This also removes the redundant concurrent full-saga reads/writes that were happening when multiple triggers raced each other, which should make the transition to the next event (inheriting `sceneSummary` — a pure local write, no network call) noticeably snappier instead of the "takes a while" feel that was reported.

## Test plan
- [ ] Manually verify: let a timeline reach its message limit and evolve/close so a `NewEvent` milestone fires, continue past it, confirm exactly one new (empty) event/timeline is created — not two.
- [ ] Manually verify: the transition to the next event after continuing feels fast (well under a second), not sluggish.
- Was not able to build/run the app in this cloud sandbox (offline, no JDK 17 toolchain available to Gradle here), so this needs manual verification on a machine with the full toolchain.

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NEovShEZC46bCXhzvw7j16

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEovShEZC46bCXhzvw7j16)_